### PR TITLE
Fix ModelLoaderCTM memory usage overhead

### DIFF
--- a/src/main/java/team/chisel/ctm/CTM.java
+++ b/src/main/java/team/chisel/ctm/CTM.java
@@ -38,6 +38,7 @@ public class CTM {
         TextureTypeRegistry.preInit(event);
 
         ModelLoaderRegistry.registerLoader(ModelLoaderCTM.INSTANCE);
+        MinecraftForge.EVENT_BUS.register(ModelLoaderCTM.INSTANCE);
         Minecraft.getMinecraft().metadataSerializer_.registerMetadataSectionType(new IMetadataSectionCTM.Serializer(), IMetadataSectionCTM.class);
         
         MinecraftForge.EVENT_BUS.register(TextureMetadataHandler.INSTANCE);


### PR DESCRIPTION
When analyzing a heap dump of Enigmatica 2: Expert, I've noticed CTM adds a constant ~105MB overhead to the memory usage, all centering in the "jsonCache" field. This is about 3.6%-4.3% of the modpack's "at main menu post-loading" Java heap usage, which is in my opinion significant.

This is the more comprehensive solution I would like to propose:

* all closeable objects opened during JSON loading are now closed (this isn't strictly relevant, but is a good idea to catch along the way in my opinion),
* the cache is fully cleared after model baking is finished, as most of its contents are no longer necessary,
* the cache map is replaced with a Guava LRU cache with a small size, as in typical usage workloads loadModel() is either called immediately after the relevant accepts() or not at all. This may help in *very* memory-strained environments (or with overzealous mods), but isn't strictly necessary (see below).

A less invasive solution implementing only the first two bullet points is provided [here](https://github.com/asiekierka/ConnectedTexturesMod/commit/179f08b05d572835c0fb6eb186482ea562bd2c5f) as an alternative.