### PR TITLE
Rewrite texture types registry API and update texture type javadoc

### DIFF
--- a/src/main/java/team/chisel/ctm/CTM.java
+++ b/src/main/java/team/chisel/ctm/CTM.java
@@ -16,7 +16,7 @@ import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import team.chisel.ctm.client.model.parsing.ModelLoaderCTM;
 import team.chisel.ctm.client.texture.IMetadataSectionCTM;
-import team.chisel.ctm.client.texture.type.TextureTypeRegistry;
+import team.chisel.ctm.client.texture.type.TextureTypes;
 import team.chisel.ctm.client.util.CTMPackReloadListener;
 import team.chisel.ctm.client.util.TextureMetadataHandler;
 
@@ -35,7 +35,7 @@ public class CTM {
     
     @EventHandler
     public void preInit(FMLPreInitializationEvent event) {
-        TextureTypeRegistry.preInit(event);
+        TextureTypes.registerAll(event.getAsmData());
 
         ModelLoaderRegistry.registerLoader(ModelLoaderCTM.INSTANCE);
         MinecraftForge.EVENT_BUS.register(ModelLoaderCTM.INSTANCE);

--- a/src/main/java/team/chisel/ctm/api/texture/TextureType.java
+++ b/src/main/java/team/chisel/ctm/api/texture/TextureType.java
@@ -24,7 +24,7 @@ import team.chisel.ctm.client.texture.type.TextureTypeCTMV;
 public @interface TextureType {
 
     /**
-     * The alias of the annotated texture type, used to reference it from model or texture metadata
+     * An alias of the annotated texture type, used to reference it from model or texture metadata
      * <p>
      * If the value is left blank (default) the alias will be inferred from the annotated field or class name
      * 

--- a/src/main/java/team/chisel/ctm/api/texture/TextureType.java
+++ b/src/main/java/team/chisel/ctm/api/texture/TextureType.java
@@ -24,11 +24,11 @@ import team.chisel.ctm.client.texture.type.TextureTypeCTMV;
 public @interface TextureType {
 
     /**
-     * The name used in JSON files to select this texture type. For example, connected textures would be "ctm"
+     * The alias of the annotated texture type, used to reference it from model or texture metadata
      * <p>
-     * This value can be left out to use the name of the class/field being annotated.
+     * If the value is left blank (default) the alias will be inferred from the annotated field or class name
      * 
-     * @return The name of the texture type.
+     * @return The alias for this texture type
      */
     String value() default "";
 }

--- a/src/main/java/team/chisel/ctm/client/texture/IMetadataSectionCTM.java
+++ b/src/main/java/team/chisel/ctm/client/texture/IMetadataSectionCTM.java
@@ -74,8 +74,7 @@ public interface IMetadataSectionCTM extends IMetadataSection {
     @Getter
     public static class V1 implements IMetadataSectionCTM {
         
-        private ITextureType type = TextureTypes.getType("NORMAL").orElseThrow(() ->
-                new IllegalStateException("Missing normal texture type"));
+        private ITextureType type = TextureTypes.normal();
         private BlockRenderLayer layer = null;
         private String proxy;
         private ResourceLocation[] additionalTextures = new ResourceLocation[0];

--- a/src/main/java/team/chisel/ctm/client/texture/IMetadataSectionCTM.java
+++ b/src/main/java/team/chisel/ctm/client/texture/IMetadataSectionCTM.java
@@ -28,7 +28,7 @@ import team.chisel.ctm.CTM;
 import team.chisel.ctm.api.texture.ICTMTexture;
 import team.chisel.ctm.api.texture.ITextureType;
 import team.chisel.ctm.api.util.TextureInfo;
-import team.chisel.ctm.client.texture.type.TextureTypeRegistry;
+import team.chisel.ctm.client.texture.type.TextureTypes;
 import team.chisel.ctm.client.util.ResourceUtil;
 
 @ParametersAreNonnullByDefault
@@ -74,7 +74,8 @@ public interface IMetadataSectionCTM extends IMetadataSection {
     @Getter
     public static class V1 implements IMetadataSectionCTM {
         
-        private ITextureType type = TextureTypeRegistry.getType("NORMAL");
+        private ITextureType type = TextureTypes.getType("NORMAL").orElseThrow(() ->
+                new IllegalStateException("Missing normal texture type"));
         private BlockRenderLayer layer = null;
         private String proxy;
         private ResourceLocation[] additionalTextures = new ResourceLocation[0];
@@ -102,12 +103,8 @@ public interface IMetadataSectionCTM extends IMetadataSection {
             if (obj.has("type")) {
                 JsonElement typeEle = obj.get("type");
                 if (typeEle.isJsonPrimitive() && typeEle.getAsJsonPrimitive().isString()) {
-                    ITextureType type = TextureTypeRegistry.getType(typeEle.getAsString());
-                    if (type == null) {
-                        throw new JsonParseException("Invalid render type given: " + typeEle);
-                    } else {
-                        ret.type = type;
-                    }
+                    ret.type = TextureTypes.getType(typeEle.getAsString()).orElseThrow(() ->
+                            new JsonParseException("Invalid texture type: " + typeEle));
                 }
             }
 

--- a/src/main/java/team/chisel/ctm/client/texture/type/TextureTypeRegistry.java
+++ b/src/main/java/team/chisel/ctm/client/texture/type/TextureTypeRegistry.java
@@ -1,86 +1,26 @@
 package team.chisel.ctm.client.texture.type;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.stream.Collectors;
-
-import com.google.common.base.Throwables;
-import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Multimap;
-
-import net.minecraft.util.StringUtils;
-import net.minecraftforge.fml.common.discovery.ASMDataTable.ASMData;
-import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import team.chisel.ctm.api.texture.ITextureType;
-import team.chisel.ctm.api.texture.TextureType;
-import team.chisel.ctm.api.texture.TextureTypeList;
+
+import java.util.Map;
 
 /**
  * Registry for all the different texture types
  */
+@Deprecated
 public class TextureTypeRegistry {
-
     private static Map<String, ITextureType> map = Maps.newHashMap();
 
-    @SuppressWarnings("unchecked")
-    public static void preInit(FMLPreInitializationEvent event) {
-        Multimap<ASMData, String> annots = HashMultimap.create();
-        for (ASMData list : event.getAsmData().getAll(TextureTypeList.class.getName())) {
-            for (String value : ((List<Map<String, String>>) list.getAnnotationInfo().get("value")).stream().map(m -> m.get("value")).collect(Collectors.toList())) {
-                annots.put(list, value);
-            }
-        }
-        for (ASMData single : event.getAsmData().getAll(TextureType.class.getName())) {
-            if (single.getObjectName() != null) {
-                annots.put(single, (String) single.getAnnotationInfo().get("value"));
-            }
-        }
-        for (Entry<ASMData, Collection<String>> data : annots.asMap().entrySet()) {
-            ITextureType type;
-            try {
-                type = ((Class<? extends ITextureType>) Class.forName(data.getKey().getClassName())).newInstance();
-            } catch (InstantiationException e) {
-                // This might be a field, let's try that
-                try {
-                    Class<?> c = Class.forName(data.getKey().getClassName());
-                    type = (ITextureType) c.getDeclaredField(data.getKey().getObjectName()).get(null);
-                } catch (IllegalArgumentException | IllegalAccessException | NoSuchFieldException | SecurityException | ClassNotFoundException e1) {
-                    // nope
-                    throw Throwables.propagate(e1);
-                }
-            } catch (IllegalAccessException | ClassNotFoundException e) {
-                throw Throwables.propagate(e);
-            }
-            for (String name : data.getValue()) {
-                if (StringUtils.isNullOrEmpty(name)) {
-                    name = data.getKey().getObjectName();
-                    name = name.substring(name.lastIndexOf('.') + 1);
-                }
-                register(name, type);
-            }
-        }
+    public static void register(String name, ITextureType type) {
+        TextureTypes.register(type, name);
     }
 
-    public static void register(String name, ITextureType type){
-        String key = name.toLowerCase(Locale.ROOT);
-        if (map.containsKey(key) && map.get(key) != type){
-            throw new IllegalArgumentException("Render Type with name "+key+" has already been registered!");
-        }
-        else if (map.get(key) != type){
-            map.put(key, type);
-        }
+    public static ITextureType getType(String name) {
+        return TextureTypes.getType(name).orElse(null);
     }
 
-    public static ITextureType getType(String name){
-        String key = name.toLowerCase(Locale.ROOT);
-        return map.get(key);
-    }
-
-    public static boolean isValid(String name){
-        return getType(name) != null;
+    public static boolean isValid(String name) {
+        return TextureTypes.isPresent(name);
     }
 }

--- a/src/main/java/team/chisel/ctm/client/texture/type/TextureTypes.java
+++ b/src/main/java/team/chisel/ctm/client/texture/type/TextureTypes.java
@@ -23,6 +23,16 @@ public final class TextureTypes {
     }
 
     /**
+     * Gets the normal (default) texture type from the registry
+     *
+     * @return The normal texture type
+     * @throws IllegalStateException If the type has not been registered yet
+     */
+    public static ITextureType normal() {
+        return getType("normal").orElseThrow(() -> new IllegalStateException("Normal texture type not registered"));
+    }
+
+    /**
      * Gets the {@link ITextureType} registered under the given {@code alias}
      *
      * @param alias An alias of the texture type

--- a/src/main/java/team/chisel/ctm/client/texture/type/TextureTypes.java
+++ b/src/main/java/team/chisel/ctm/client/texture/type/TextureTypes.java
@@ -1,0 +1,145 @@
+package team.chisel.ctm.client.texture.type;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import net.minecraftforge.fml.common.discovery.ASMDataTable;
+import net.minecraftforge.fml.common.discovery.ASMDataTable.ASMData;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import team.chisel.ctm.api.texture.ITextureType;
+import team.chisel.ctm.api.texture.TextureType;
+
+import java.util.Collection;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+public final class TextureTypes {
+    private static final Map<String, ITextureType> REGISTRY = Maps.newHashMap();
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private TextureTypes() {
+    }
+
+    /**
+     * Gets the {@link ITextureType} registered under the given {@code alias}
+     *
+     * @param alias An alias of the texture type
+     * @return An optional of the texture type, which will be empty if none is registered
+     */
+    public static Optional<ITextureType> getType(final String alias) {
+        return Optional.ofNullable(REGISTRY.get(lowerCase(alias)));
+    }
+
+    /**
+     * Gets all registered aliases for the given {@code type}
+     *
+     * @param type The texture type
+     * @return The texture type's aliases
+     */
+    public static Collection<String> getAliases(final ITextureType type) {
+        final ImmutableSet.Builder<String> builder = ImmutableSet.builder();
+        for (final Map.Entry<String, ITextureType> entry : REGISTRY.entrySet()) {
+            if (type.equals(entry.getValue())) {
+                builder.add(entry.getKey());
+            }
+        }
+        return builder.build();
+    }
+
+    /**
+     * Determines whether the given {@code alias} is registered to any {@link ITextureType}
+     *
+     * @param alias A texture type alias
+     * @return True if the given {@code alias} is registered
+     */
+    public static boolean isPresent(final String alias) {
+        return REGISTRY.containsKey(lowerCase(alias));
+    }
+
+    /**
+     * Registers the given {@code type} under the given {@code alias}
+     *
+     * @param type The texture type to be registered
+     * @param alias An alias of the texture type
+     * @throws IllegalArgumentException If the given type or an existing
+     *         type are already registered any of the given aliases
+     */
+    public static void register(final ITextureType type, String alias) {
+        Preconditions.checkArgument(type != null, "Cannot register a null type");
+        alias = lowerCase(alias);
+        if (REGISTRY.containsKey(alias)) {
+            if (type.equals(REGISTRY.get(alias))) {
+                // TODO This should be a failure condition now that the annotation parsing isn't duplicating registration
+                LOGGER.warn("Duplicate registration of a type under alias {}." +
+                        " Duplicate registration will be a failure condition in future versions of CTM", alias);
+                return;
+            }
+            throw new IllegalArgumentException("An existing type is already registered under alias " + alias);
+        }
+        LOGGER.debug("Registering alias {} for type {}", alias, type);
+        REGISTRY.put(alias, type);
+    }
+
+    /**
+     * Registers the given {@code type} under the given {@code aliases}
+     *
+     * @param type The texture type to be registered
+     * @param aliases The aliases of the texture type
+     * @throws IllegalArgumentException If the given type or an existing
+     *         type are already registered any of the given aliases
+     */
+    public static void register(final ITextureType type, final String... aliases) {
+        for (final String alias : aliases) {
+            register(type, alias);
+        }
+    }
+
+    /**
+     * Registers any fields and classes annotated with {@link TextureType}
+     * that have been discovered and stored in the given {@link ASMDataTable}
+     *
+     * @param table The ASM data table for this runtime
+     */
+    public static void registerAll(final ASMDataTable table) {
+        for (final ASMData data : table.getAll(TextureType.class.getName())) {
+            register(getTypeInstance(data), getTypeAlias(data));
+        }
+    }
+
+    private static String getTypeAlias(final ASMData data) {
+        final String alias = (String) data.getAnnotationInfo().get("value");
+        return alias.isEmpty() ? inferAliasFromType(data) : alias;
+    }
+
+    private static ITextureType getTypeInstance(final ASMData data) {
+        final String className = data.getClassName();
+        final String objectName = data.getObjectName();
+        final boolean isClass = className.equals(objectName);
+        try {
+            final Class<?> target = Class.forName(className);
+            if (isClass) {
+                return (ITextureType) target.getConstructor().newInstance();
+            }
+            return (ITextureType) target.getField(objectName).get(null);
+        } catch (final ReflectiveOperationException e) {
+            throw new RuntimeException(isClass ? "Constructing texture type" : "Getting texture type", e);
+        }
+    }
+
+    // TODO Consider formatting pascal and lower camel to lower underscore to follow naming standards of game registries
+    // TODO Consider stripping outer class qualifiers ($ recursive), possibly map to underscores if implementing above
+    private static String inferAliasFromType(final ASMData data) {
+        final String className = data.getClassName();
+        final String objectName = data.getObjectName();
+        if (className.equals(objectName)) {
+            return className.substring(className.lastIndexOf('.') + 1);
+        }
+        return objectName;
+    }
+
+    private static String lowerCase(final String rawAlias) {
+        return rawAlias.toLowerCase(Locale.ROOT);
+    }
+}


### PR DESCRIPTION
This pull request contains a single binary change: Types during registration are now compared using object equality rather than referential equality. I considered this to be a bug, but if desired I can continue using referential equality during registration and will add a "todo" for object equality in future versions.

Regarding code style, I can remove the final modifiers on the parameters and class if desired. The same applies to the class' private constructor. I personally prefer these decorations as it prevents accidental reassignment of parameters (and in turn makes it clear if a parameter is ever reassigned in the method body). A class with a private constructor is implicitly final, so adding the modifier is just for clarity. The private constructor is because I consider this to be a utility class, and utility classes shouldn't be instantiable.
