### PR TITLE
Move model loader registration to constructor

### DIFF
--- a/src/main/java/team/chisel/ctm/CTM.java
+++ b/src/main/java/team/chisel/ctm/CTM.java
@@ -36,16 +36,11 @@ public class CTM {
     	
     	DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> {
     	    IEventBus modBus = FMLJavaModLoadingContext.get().getModEventBus();
-    	    modBus.addListener(this::preInit);
+    	    ModelLoaderRegistry.registerLoader(new ResourceLocation(MOD_ID, "ctm"), ModelLoaderCTM.INSTANCE);
     	    modBus.register(TextureMetadataHandler.INSTANCE);
     	    modBus.register(new CTMPackReloadListener());
     	    
             TextureTypeRegistry.scan();
     	});
-    }
-    
-    @SubscribeEvent
-    public void preInit(FMLClientSetupEvent event) {
-        ModelLoaderRegistry.registerLoader(new ResourceLocation(MOD_ID, "ctm"), ModelLoaderCTM.INSTANCE);
     }
 }


### PR DESCRIPTION
This fixes an error caused by the model loader not being registered before resources are initially loaded. I am unable to reproduce the issue in-dev with a loaded resource pack depending on `ctm:ctm` so it is possible that there is a race condition? This pull request is a proof-of-concept change for now, and I've confirmed that this change does fix the error produced in a production environment. A copy of a startup log including the error can be seen below.

```
MultiMC version: 0.6.11-1430


Minecraft folder is:
E:/Minecraft/Instances/Coalescence/.minecraft


Java path is:
C:/Program Files/AdoptOpenJDK/jdk-8.0.252.09-hotspot/bin/javaw.exe


Java is version 1.8.0_252, using 64-bit architecture.


Main Class:
  io.github.zekerzhayard.forgewrapper.installer.Main

Native path:
  E:/Minecraft/Instances/Coalescence/natives

Traits:
traits FirstThreadOnMacOS

Libraries:
  E:/Minecraft/MultiMC/libraries/org/lwjgl/lwjgl-glfw/3.2.2/lwjgl-glfw-3.2.2.jar
  E:/Minecraft/MultiMC/libraries/org/lwjgl/lwjgl-jemalloc/3.2.2/lwjgl-jemalloc-3.2.2.jar
  E:/Minecraft/MultiMC/libraries/org/lwjgl/lwjgl-openal/3.2.2/lwjgl-openal-3.2.2.jar
  E:/Minecraft/MultiMC/libraries/org/lwjgl/lwjgl-opengl/3.2.2/lwjgl-opengl-3.2.2.jar
  E:/Minecraft/MultiMC/libraries/org/lwjgl/lwjgl-stb/3.2.2/lwjgl-stb-3.2.2.jar
  E:/Minecraft/MultiMC/libraries/org/lwjgl/lwjgl-tinyfd/3.2.2/lwjgl-tinyfd-3.2.2.jar
  E:/Minecraft/MultiMC/libraries/org/lwjgl/lwjgl/3.2.2/lwjgl-3.2.2.jar
  E:/Minecraft/MultiMC/libraries/com/mojang/patchy/1.1/patchy-1.1.jar
  E:/Minecraft/MultiMC/libraries/oshi-project/oshi-core/1.1/oshi-core-1.1.jar
  E:/Minecraft/MultiMC/libraries/net/java/dev/jna/jna/4.4.0/jna-4.4.0.jar
  E:/Minecraft/MultiMC/libraries/net/java/dev/jna/platform/3.4.0/platform-3.4.0.jar
  E:/Minecraft/MultiMC/libraries/com/ibm/icu/icu4j-core-mojang/51.2/icu4j-core-mojang-51.2.jar
  E:/Minecraft/MultiMC/libraries/com/mojang/javabridge/1.0.22/javabridge-1.0.22.jar
  E:/Minecraft/MultiMC/libraries/net/sf/jopt-simple/jopt-simple/5.0.4/jopt-simple-5.0.4.jar
  E:/Minecraft/MultiMC/libraries/io/netty/netty-all/4.1.25.Final/netty-all-4.1.25.Final.jar
  E:/Minecraft/MultiMC/libraries/com/google/guava/guava/21.0/guava-21.0.jar
  E:/Minecraft/MultiMC/libraries/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar
  E:/Minecraft/MultiMC/libraries/commons-io/commons-io/2.5/commons-io-2.5.jar
  E:/Minecraft/MultiMC/libraries/commons-codec/commons-codec/1.10/commons-codec-1.10.jar
  E:/Minecraft/MultiMC/libraries/com/mojang/brigadier/1.0.17/brigadier-1.0.17.jar
  E:/Minecraft/MultiMC/libraries/com/mojang/datafixerupper/2.0.24/datafixerupper-2.0.24.jar
  E:/Minecraft/MultiMC/libraries/com/google/code/gson/gson/2.8.0/gson-2.8.0.jar
  E:/Minecraft/MultiMC/libraries/com/mojang/authlib/1.5.25/authlib-1.5.25.jar
  E:/Minecraft/MultiMC/libraries/org/apache/commons/commons-compress/1.8.1/commons-compress-1.8.1.jar
  E:/Minecraft/MultiMC/libraries/org/apache/httpcomponents/httpclient/4.3.3/httpclient-4.3.3.jar
  E:/Minecraft/MultiMC/libraries/commons-logging/commons-logging/1.1.3/commons-logging-1.1.3.jar
  E:/Minecraft/MultiMC/libraries/org/apache/httpcomponents/httpcore/4.3.2/httpcore-4.3.2.jar
  E:/Minecraft/MultiMC/libraries/it/unimi/dsi/fastutil/8.2.1/fastutil-8.2.1.jar
  E:/Minecraft/MultiMC/libraries/org/apache/logging/log4j/log4j-api/2.11.2/log4j-api-2.11.2.jar
  E:/Minecraft/MultiMC/libraries/org/apache/logging/log4j/log4j-core/2.11.2/log4j-core-2.11.2.jar
  E:/Minecraft/MultiMC/libraries/com/mojang/text2speech/1.11.3/text2speech-1.11.3.jar
  E:/Minecraft/MultiMC/libraries/io/github/zekerzhayard/ForgeWrapper/1.4.2/ForgeWrapper-1.4.2.jar
  E:/Minecraft/MultiMC/libraries/net/minecraftforge/forge/1.15.2-31.2.33/forge-1.15.2-31.2.33-launcher.jar
  E:/Minecraft/MultiMC/libraries/org/ow2/asm/asm/7.2/asm-7.2.jar
  E:/Minecraft/MultiMC/libraries/org/ow2/asm/asm-commons/7.2/asm-commons-7.2.jar
  E:/Minecraft/MultiMC/libraries/org/ow2/asm/asm-tree/7.2/asm-tree-7.2.jar
  E:/Minecraft/MultiMC/libraries/cpw/mods/modlauncher/5.1.2/modlauncher-5.1.2.jar
  E:/Minecraft/MultiMC/libraries/cpw/mods/grossjava9hacks/1.3.0/grossjava9hacks-1.3.0.jar
  E:/Minecraft/MultiMC/libraries/net/minecraftforge/accesstransformers/2.1.3-shadowed/accesstransformers-2.1.3-shadowed.jar
  E:/Minecraft/MultiMC/libraries/net/minecraftforge/eventbus/2.2.0-service/eventbus-2.2.0-service.jar
  E:/Minecraft/MultiMC/libraries/net/minecraftforge/forgespi/3.0.0/forgespi-3.0.0.jar
  E:/Minecraft/MultiMC/libraries/net/minecraftforge/coremods/2.0.3/coremods-2.0.3.jar
  E:/Minecraft/MultiMC/libraries/net/minecraftforge/unsafe/0.2.0/unsafe-0.2.0.jar
  E:/Minecraft/MultiMC/libraries/com/electronwill/night-config/core/3.6.2/core-3.6.2.jar
  E:/Minecraft/MultiMC/libraries/com/electronwill/night-config/toml/3.6.2/toml-3.6.2.jar
  E:/Minecraft/MultiMC/libraries/org/jline/jline/3.12.1/jline-3.12.1.jar
  E:/Minecraft/MultiMC/libraries/org/apache/maven/maven-artifact/3.6.0/maven-artifact-3.6.0.jar
  E:/Minecraft/MultiMC/libraries/net/jodah/typetools/0.8.1/typetools-0.8.1.jar
  E:/Minecraft/MultiMC/libraries/net/minecrell/terminalconsoleappender/1.2.0/terminalconsoleappender-1.2.0.jar
  E:/Minecraft/MultiMC/libraries/com/mojang/minecraft/1.15.2/minecraft-1.15.2-client.jar

Native libraries:
  E:/Minecraft/MultiMC/libraries/org/lwjgl/lwjgl-glfw/3.2.2/lwjgl-glfw-3.2.2-natives-windows.jar
  E:/Minecraft/MultiMC/libraries/org/lwjgl/lwjgl-jemalloc/3.2.2/lwjgl-jemalloc-3.2.2-natives-windows.jar
  E:/Minecraft/MultiMC/libraries/org/lwjgl/lwjgl-openal/3.2.2/lwjgl-openal-3.2.2-natives-windows.jar
  E:/Minecraft/MultiMC/libraries/org/lwjgl/lwjgl-opengl/3.2.2/lwjgl-opengl-3.2.2-natives-windows.jar
  E:/Minecraft/MultiMC/libraries/org/lwjgl/lwjgl-stb/3.2.2/lwjgl-stb-3.2.2-natives-windows.jar
  E:/Minecraft/MultiMC/libraries/org/lwjgl/lwjgl-tinyfd/3.2.2/lwjgl-tinyfd-3.2.2-natives-windows.jar
  E:/Minecraft/MultiMC/libraries/org/lwjgl/lwjgl/3.2.2/lwjgl-3.2.2-natives-windows.jar
  E:/Minecraft/MultiMC/libraries/com/mojang/text2speech/1.11.3/text2speech-1.11.3-natives-windows.jar

Mods:
  [✔️] CTM-MC1.15.2-1.1.0.10

Params:
  --username  --version MultiMC5 --gameDir E:/Minecraft/Instances/Coalescence/.minecraft --assetsDir E:/Minecraft/MultiMC/assets --assetIndex 1.15 --uuid  --accessToken  --userType  --versionType release --launchTarget fmlclient --fml.forgeVersion 31.2.33 --fml.mcVersion 1.15.2 --fml.forgeGroup net.minecraftforge --fml.mcpVersion 20200515.085601

Window size: 1280 x 720

Java Arguments:
[-XX:HeapDumpPath=MojangTricksIntelDriversForPerformance_javaw.exe_minecraft.exe.heapdump, -Xms1024m, -Xmx8192m, -Duser.language=en]


Minecraft process ID: 1296


Using onesix launcher.

2020-07-30 17:25:36,636 main WARN Advanced terminal features are not available in this environment
[32m[17:25:36] [main/INFO] [cp.mo.mo.Launcher/MODLAUNCHER]: ModLauncher running: args [--username, HeckinChloe, --version, MultiMC5, --gameDir, E:/Minecraft/Instances/Coalescence/.minecraft, --assetsDir, E:/Minecraft/MultiMC/assets, --assetIndex, 1.15, --uuid, <PROFILE ID>, --accessToken, ????????, --userType, mojang, --versionType, release, --launchTarget, fmlclient, --fml.forgeVersion, 31.2.33, --fml.mcVersion, 1.15.2, --fml.forgeGroup, net.minecraftforge, --fml.mcpVersion, 20200515.085601, --width, 1280, --height, 720]
[m[32m[17:25:36] [main/INFO] [cp.mo.mo.Launcher/MODLAUNCHER]: ModLauncher 5.1.2+70+master.2845bb9 starting: java version 1.8.0_252 by AdoptOpenJDK
[m[32m[17:25:36] [main/INFO] [ne.mi.fm.lo.FixSSL/CORE]: Added Lets Encrypt root certificates as additional trust
[m[32m[17:25:38] [main/INFO] [cp.mo.mo.LaunchServiceHandler/MODLAUNCHER]: Launching target 'fmlclient' with arguments [--version, MultiMC5, --gameDir, E:\Minecraft\Instances\Coalescence\.minecraft, --assetsDir, E:\Minecraft\MultiMC\assets, --uuid, <PROFILE ID>, --username, HeckinChloe, --assetIndex, 1.15, --accessToken, ????????, --userType, mojang, --versionType, release, --width, 1280, --height, 720]
[m[32m[17:25:39] [Render thread/INFO] [minecraft/Minecraft]: Setting user: HeckinChloe
[m[32m[17:25:45] [Render thread/INFO] [minecraft/Minecraft]: Backend library: LWJGL version 3.2.2 build 10
[m[32m[17:25:46] [modloading-worker-1/INFO] [ne.mi.co.ForgeMod/FORGEMOD]: Forge mod loading, version 31.2.33, for MC 1.15.2 with MCP 20200515.085601
[m[32m[17:25:46] [modloading-worker-1/INFO] [ne.mi.co.MinecraftForge/FORGE]: MinecraftForge v31.2.33 Initialized
[m[32m[17:25:49] [Render thread/INFO] [mojang/NarratorWindows]: Narrator library for x64 successfully loaded
[m[32m[17:25:49] [Render thread/INFO] [minecraft/SimpleReloadableResourceManager]: Reloading ResourceManager: Default, Mod Resources, Coalescence
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: java.lang.IllegalStateException: Model loader 'ctm:ctm' not found. Registered loaders: forge:obj, forge:composite, forge:item-layers, forge:multi-layer, forge:bucket, minecraft:elements
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraftforge.client.model.ModelLoaderRegistry.getModel(ModelLoaderRegistry.java:103)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraftforge.client.model.ModelLoaderRegistry.deserializeGeometry(ModelLoaderRegistry.java:125)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraftforge.client.model.ModelLoaderRegistry$ExpandedBlockModelDeserializer.deserialize(ModelLoaderRegistry.java:362)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraftforge.client.model.ModelLoaderRegistry$ExpandedBlockModelDeserializer.deserialize(ModelLoaderRegistry.java:346)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at com.google.gson.internal.bind.TreeTypeAdapter.read(TreeTypeAdapter.java:69)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraft.util.JSONUtils.func_188173_a(SourceFile:494)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraft.util.JSONUtils.func_193839_a(SourceFile:534)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraft.client.renderer.model.BlockModel.func_178307_a(BlockModel.java:63)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraft.client.renderer.model.ModelBakery.func_177594_c(ModelBakery.java:535)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraft.client.renderer.model.ModelBakery.func_209598_b(ModelBakery.java:330)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraft.client.renderer.model.ModelBakery.func_209597_a(ModelBakery.java:311)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraft.client.renderer.model.ModelBakery.func_217843_a(ModelBakery.java:469)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraft.client.renderer.model.ModelBakery.lambda$processLoading$8(ModelBakery.java:181)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at com.google.common.collect.ImmutableList.forEach(ImmutableList.java:408)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraft.client.renderer.model.ModelBakery.processLoading(ModelBakery.java:180)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraftforge.client.model.ModelLoader.<init>(ModelLoader.java:72)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraft.client.renderer.model.ModelManager.func_212854_a_(ModelManager.java:55)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraft.client.renderer.model.ModelManager.func_212854_a_(ModelManager.java:19)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraft.client.resources.ReloadListener.func_215270_b(SourceFile:11)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1604)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.java:1596)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
[m[33m[17:25:49] [Server-Worker-2/WARN] [minecraft/ModelBakery]: Unable to load model: 'minecraft:block/stone' referenced from: minecraft:stone#: java.lang.IllegalStateException: Model loader 'ctm:ctm' not found. Registered loaders: forge:obj, forge:composite, forge:item-layers, forge:multi-layer, forge:bucket, minecraft:elements
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: java.lang.IllegalStateException: Model loader 'ctm:ctm' not found. Registered loaders: forge:obj, forge:composite, forge:item-layers, forge:multi-layer, forge:bucket, minecraft:elements
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraftforge.client.model.ModelLoaderRegistry.getModel(ModelLoaderRegistry.java:103)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraftforge.client.model.ModelLoaderRegistry.deserializeGeometry(ModelLoaderRegistry.java:125)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraftforge.client.model.ModelLoaderRegistry$ExpandedBlockModelDeserializer.deserialize(ModelLoaderRegistry.java:362)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraftforge.client.model.ModelLoaderRegistry$ExpandedBlockModelDeserializer.deserialize(ModelLoaderRegistry.java:346)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at com.google.gson.internal.bind.TreeTypeAdapter.read(TreeTypeAdapter.java:69)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraft.util.JSONUtils.func_188173_a(SourceFile:494)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraft.util.JSONUtils.func_193839_a(SourceFile:534)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraft.client.renderer.model.BlockModel.func_178307_a(BlockModel.java:63)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraft.client.renderer.model.ModelBakery.func_177594_c(ModelBakery.java:535)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraft.client.renderer.model.ModelBakery.func_209598_b(ModelBakery.java:330)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraft.client.renderer.model.ModelBakery.func_209597_a(ModelBakery.java:311)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraft.client.renderer.model.ModelBakery.func_217843_a(ModelBakery.java:469)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraft.client.renderer.model.ModelBakery.lambda$processLoading$8(ModelBakery.java:181)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at com.google.common.collect.ImmutableList.forEach(ImmutableList.java:408)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraft.client.renderer.model.ModelBakery.processLoading(ModelBakery.java:180)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraftforge.client.model.ModelLoader.<init>(ModelLoader.java:72)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraft.client.renderer.model.ModelManager.func_212854_a_(ModelManager.java:55)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraft.client.renderer.model.ModelManager.func_212854_a_(ModelManager.java:19)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at net.minecraft.client.resources.ReloadListener.func_215270_b(SourceFile:11)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1604)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.java:1596)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
[m[32m[17:25:49] [Server-Worker-2/INFO] [STDERR/]: [net.minecraftforge.client.model.ModelLoaderRegistry:getModel:113]: 	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
[m[33m[17:25:49] [Server-Worker-2/WARN] [minecraft/ModelBakery]: Unable to load model: 'minecraft:block/stone_mirrored' referenced from: minecraft:stone#: java.lang.IllegalStateException: Model loader 'ctm:ctm' not found. Registered loaders: forge:obj, forge:composite, forge:item-layers, forge:multi-layer, forge:bucket, minecraft:elements
[m[32m[17:25:49] [Forge Version Check/INFO] [ne.mi.fm.VersionChecker/]: [forge] Starting version check at https://files.minecraftforge.net/maven/net/minecraftforge/forge/promotions_slim.json
[m[32m[17:25:50] [Forge Version Check/INFO] [ne.mi.fm.VersionChecker/]: [forge] Found status: AHEAD Current: 31.2.33 Target: null
[m[33m[17:25:51] [Server-Worker-2/WARN] [minecraft/ModelBakery]: Unable to resolve texture reference: #missingno in minecraft:item/infested_stone
[m[33m[17:25:51] [Server-Worker-2/WARN] [minecraft/ModelBakery]: Unable to resolve texture reference: #missingno in minecraft:item/stone
[m[32m[17:25:53] [Render thread/INFO] [minecraft/SoundSystem]: OpenAL initialized.
[m[32m[17:25:53] [Render thread/INFO] [minecraft/SoundEngine]: Sound engine started
[m[32m[17:25:53] [Render thread/INFO] [minecraft/AtlasTexture]: Created: 1024x512x4 minecraft:textures/atlas/blocks.png-atlas
[m[32m[17:25:53] [Render thread/INFO] [minecraft/AtlasTexture]: Created: 128x128x4 minecraft:textures/atlas/signs.png-atlas
[m[32m[17:25:53] [Render thread/INFO] [minecraft/AtlasTexture]: Created: 512x512x4 minecraft:textures/atlas/banner_patterns.png-atlas
[m[32m[17:25:53] [Render thread/INFO] [minecraft/AtlasTexture]: Created: 512x512x4 minecraft:textures/atlas/shield_patterns.png-atlas
[m[32m[17:25:53] [Render thread/INFO] [minecraft/AtlasTexture]: Created: 256x256x4 minecraft:textures/atlas/chest.png-atlas
[m[32m[17:25:53] [Render thread/INFO] [minecraft/AtlasTexture]: Created: 512x256x4 minecraft:textures/atlas/beds.png-atlas
[m[32m[17:25:53] [Render thread/INFO] [minecraft/AtlasTexture]: Created: 512x256x4 minecraft:textures/atlas/shulker_boxes.png-atlas
[m[32m[17:25:54] [Render thread/INFO] [minecraft/AtlasTexture]: Created: 256x256x0 minecraft:textures/atlas/particles.png-atlas
[m[32m[17:25:54] [Render thread/INFO] [minecraft/AtlasTexture]: Created: 256x256x0 minecraft:textures/atlas/paintings.png-atlas
[m[32m[17:25:54] [Render thread/INFO] [minecraft/AtlasTexture]: Created: 128x128x0 minecraft:textures/atlas/mob_effects.png-atlas
```