### PR TITLE
consider all possible block state instead of only default block state model for render type setting

### DIFF
--- a/src/main/java/team/chisel/ctm/client/util/CTMPackReloadListener.java
+++ b/src/main/java/team/chisel/ctm/client/util/CTMPackReloadListener.java
@@ -68,12 +68,21 @@ public class CTMPackReloadListener extends SimplePreparableReloadListener<Unit> 
         blockRenderChecks.clear();
 
         for (Block block : ForgeRegistries.BLOCKS.getValues()) {
-            BlockState state = block.defaultBlockState();
-            Predicate<RenderType> predicate = getLayerCheck(state, Minecraft.getInstance().getModelManager().getBlockModelShaper().getBlockModel(state));
+            Predicate<RenderType> predicateAll = null;
+            for (BlockState state : block.getStateDefinition().getPossibleStates()) {
+                Predicate<RenderType> predicate = getLayerCheck(state, Minecraft.getInstance().getModelManager().getBlockModelShaper().getBlockModel(state));
+                if (predicate != null){
+                    if (predicateAll != null){
+                        predicateAll = predicateAll.or(predicate);
+                    }else {
+                        predicateAll = predicate;
+                    }
+                }
+            }
 
-            if (predicate != null) {
+            if (predicateAll != null) {
                 blockRenderChecks.put(block.delegate, getExistingRenderCheck(block));
-                ItemBlockRenderTypes.setRenderLayer(block, predicate);
+                ItemBlockRenderTypes.setRenderLayer(block, predicateAll);
             }
         }
     }


### PR DESCRIPTION
the origin logic for setting render type is this
```java
for (Block block : ForgeRegistries.BLOCKS.getValues()) {
    BlockState state = block.defaultBlockState();
    Predicate<RenderType> predicate = getLayerCheck(state, Minecraft.getInstance().getModelManager().getBlockModelShaper().getBlockModel(state));
    if (predicate != null) {
        blockRenderChecks.put(block.delegate, getExistingRenderCheck(block));
        ItemBlockRenderTypes.setRenderLayer(block, predicate);
    }
}
```

the problem is that it only considers the default block state's model.  
for example, the redstone ore's default block state is `LIT:false` .  
if I only set the `LIT:true` model and need it to use layer/rendertype cutout  
```java
private @Nullable Predicate<RenderType> getLayerCheck(BlockState state, BakedModel model) {
    if (model instanceof AbstractCTMBakedModel ctmModel) {
        return layer -> ctmModel.getModel().canRenderInLayer(state, layer);
    }
    if (model instanceof WeightedBakedModel weightedModel) {
        return CachingLayerCheck.of(state, weightedModel.list, wm -> wm.getData());
    }
    if (model instanceof MultiPartBakedModel multiPartModel) {
        return CachingLayerCheck.of(state, multiPartModel.selectors, Pair::getRight);
    }
    return null;
}
```
the Predicate produce function will just return null as the `LIT:false` model is not any instance below  
the layer/rendertype setting in `LIT:false`  model is ignored  

so , just use `block.getStateDefinition().getPossibleStates()` and `Predicate#or` to consider all models' setting  

the problem is that if a block has many states, this may become a performance issue.  
though forge add `canRenderInLayer` to replace `getRenderLayer` to allow one block to have multi rendertypes  
current implementation just convert parameter from blockstae -> state  
the map which stores the information is also `Map<IRegistryDelegate<Block>, Predicate<RenderType>>`
though we can just cache `solid, cutout_mipped, cutout, translucent, tripwire` 
but it is not good for rendertype usage like https://github.com/MinecraftForge/MinecraftForge/pull/8331