### PR TITLE
Fix some issues with the 1.19 version of CTM

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 mod_version=1.1.7
 minecraft_version=1.19.2
-forge_version=43.1.3
+forge_version=43.2.8
 
 curse_type=beta
 projectId=267602

--- a/src/main/java/team/chisel/ctm/api/model/IModelCTM.java
+++ b/src/main/java/team/chisel/ctm/api/model/IModelCTM.java
@@ -2,6 +2,7 @@ package team.chisel.ctm.api.model;
 
 import java.util.Collection;
 
+import java.util.Set;
 import javax.annotation.Nullable;
 
 import net.minecraft.client.renderer.RenderType;
@@ -20,6 +21,8 @@ public interface IModelCTM extends IUnbakedGeometry<IModelCTM> {
     ICTMTexture<?> getTexture(ResourceLocation loc);
 
     boolean canRenderInLayer(BlockState state, RenderType layer);
+
+    Set<RenderType> getExtraLayers(BlockState state);
 
     @Nullable
     TextureAtlasSprite getOverrideSprite(int tintIndex);

--- a/src/main/java/team/chisel/ctm/client/model/ModelCTM.java
+++ b/src/main/java/team/chisel/ctm/client/model/ModelCTM.java
@@ -3,6 +3,7 @@ package team.chisel.ctm.client.model;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -66,7 +67,9 @@ public class ModelCTM implements IModelCTM {
     protected Map<Pair<Integer, ResourceLocation>, ICTMTexture<?>> textureOverrides;
 
     private final Collection<ResourceLocation> textureDependencies;
-    
+
+    private final Set<RenderType> extraLayers = new HashSet<>();
+    private final Set<RenderType> extraLayersView = Collections.unmodifiableSet(extraLayers);
     private transient byte layers;
 
     private Map<ResourceLocation, ICTMTexture<?>> textures = new HashMap<>();
@@ -162,7 +165,13 @@ public class ModelCTM implements IModelCTM {
 		        } else {
 		            tex = meta.get().makeTexture(sprite, spriteGetter);
 		        }
-		        layers |= 1 << (tex.getLayer() == null ? 7 : tex.getLayer().ordinal());
+                BlockRenderLayer renderLayer = tex.getLayer();
+                if (renderLayer != null) {
+                    extraLayers.add(renderLayer.getRenderType());
+                    layers |= 1 << renderLayer.ordinal();
+                } else {
+                    layers |= 1 << 7;
+                }
 		        return tex;
 		    });
 		}
@@ -190,7 +199,13 @@ public class ModelCTM implements IModelCTM {
                     	sprite = spriteGetter.apply(new Material(TextureAtlas.LOCATION_BLOCKS, texLoc));
                     }
                     ICTMTexture<?> tex = e.getValue().makeTexture(sprite, spriteGetter);
-                    layers |= 1 << (tex.getLayer() == null ? 7 : tex.getLayer().ordinal());
+                    BlockRenderLayer renderLayer = tex.getLayer();
+                    if (renderLayer != null) {
+                        extraLayers.add(renderLayer.getRenderType());
+                        layers |= 1 << renderLayer.ordinal();
+                    } else {
+                        layers |= 1 << 7;
+                    }
                     textureOverrides.put(Pair.of(e.getIntKey(), texLoc), tex);
                 }
             }
@@ -214,6 +229,11 @@ public class ModelCTM implements IModelCTM {
     public boolean canRenderInLayer(BlockState state, RenderType layer) {
         // sign bit is used to signify that a layer-less (vanilla) texture is present
         return (layers < 0 && CTMPackReloadListener.canRenderInLayerFallback(state, layer)) || ((layers >> BlockRenderLayer.fromType(layer).ordinal()) & 1) == 1;
+    }
+
+    @Override
+    public Set<RenderType> getExtraLayers(BlockState state) {
+        return extraLayersView;
     }
 
     @Override

--- a/src/main/java/team/chisel/ctm/client/util/Quad.java
+++ b/src/main/java/team/chisel/ctm/client/util/Quad.java
@@ -426,6 +426,7 @@ public class Quad {
         builder.setDirection(this.builder.quadOrientation);
         builder.setTintIndex(this.builder.quadTint);
         builder.setShade(this.builder.applyDiffuseLighting);
+        builder.setHasAmbientOcclusion(this.builder.applyAmbientOcclusion);
         builder.setSprite(this.uvs.getSprite());
         var format = DefaultVertexFormat.BLOCK;
         
@@ -508,6 +509,8 @@ public class Quad {
 
         @Setter
         private boolean applyDiffuseLighting;
+        @Setter
+        private boolean applyAmbientOcclusion;
         
         private final float[][] positions = new float[4][];
         private final float[][] uvs = new float[4][];
@@ -519,6 +522,7 @@ public class Quad {
             setQuadTint(baked.getTintIndex());
             setQuadOrientation(baked.getDirection());
             setApplyDiffuseLighting(baked.isShade());
+            setApplyAmbientOcclusion(baked.hasAmbientOcclusion());
             var vertices = baked.getVertices();
             for (int i = 0; i < 4; i++) {
                 int offset = i * STRIDE;

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml"
-loaderVersion="[38,)"
+loaderVersion="[43,)"
 issueTrackerURL="https://github.com/Chisel-Team/ConnectedTexturesMod/issues/"
 license="GPL-2.0"
 
@@ -17,6 +17,6 @@ license="GPL-2.0"
 [[dependencies.ctm]]
     modId="forge"
     mandatory=true
-    versionRange="[38.0.17,)"
+    versionRange="[43.1.24,)"
     ordering="NONE"
     side="BOTH"


### PR DESCRIPTION
Changes:
- Bumps dev version of forge to latest (43.2.8)
- Bumps min version of forge to 43.1.24 and ensures that ambient occlusion is not stripped when unbaking and rebaking quads (#202)
- Fixed always (except for leaves) including solid as a render type for baked CTM models which was causing the sugar cane CTM test resources to render with black boxes as opposed to respecting cutout
- Fixed using default render types instead of model based types for rendering the item variants of baked CTM models which was causing translucent based blocks to render incorrectly as can be seen by the pictures of the item variants in #202 
- Respect model render types for fallback in baked CTM model rather than using the broken `canRenderInLayerFallback` method

Questions/comments:
- Given I am having to bump the forge version anyway, should I bump it to `43.1.56` (as it is still before the latest RB) instead so that `Quad` can make use of the helper `QuadBakingVertexConsumer.Buffered` class instead of having to manually handle the single element Quad array for baking purposes?
- In `ModelCTM` the formatting displays incorrectly for one of the changes as that section of code uses a mix of tabs and spaces so I am not quite sure what formatting it is supposed to have so if you have any input let me know and I can fix it.
- I am not fully positive about the desired rendering of items for CTM so I am basically having it do what it was which is defaulting to how the base block version would render, but figured I should ask if this should use the new `getExtraLayers` method directly or not
- How should I handle the breaking change I did in `IModelCTM`? In theory I could default the new method to calling `canRenderInLayer` for each of the render types in `BlockRenderLayer`, but that would potentially have the same issue for implementers as existed for sugar cane depending on implementation. Though I am guessing it is worthwhile to do this just to avoid the breaking change? Also should I even be passing the block state parameter to it (it is unused)
- Following the previous comment/question should I deprecate the `canRenderInLayer` method for removal? As it is no longer really used anywhere and has been superseded by the new `getExtraLayers` method
- Should I delete a good portion of `CTMPackReloadListener` as the layer hacks aren't used, and the only place the layer fallback check is used now is in `ModelCTM#canRenderInLayer`, which could potentially just turn that method into: `Minecraft.getInstance().getModelManager().getBlockModelShaper().getBlockModel(state).getRenderTypes(state, RandomSource.create(42), ModelData.EMPTY).contains(type)` as CTM no longer overrides the actual set render types

I am opening this as a draft PR for now to make sure the questions and comments can be addressed before this gets merged.