### PR TITLE
Fix some issues with the 1.20 version of CTM

### DIFF
--- a/src/main/java/team/chisel/ctm/api/model/IModelCTM.java
+++ b/src/main/java/team/chisel/ctm/api/model/IModelCTM.java
@@ -2,6 +2,7 @@ package team.chisel.ctm.api.model;
 
 import java.util.Collection;
 
+import java.util.Set;
 import javax.annotation.Nullable;
 
 import net.minecraft.client.renderer.RenderType;
@@ -19,7 +20,7 @@ public interface IModelCTM extends IUnbakedGeometry<IModelCTM> {
     
     ICTMTexture<?> getTexture(ResourceLocation loc);
 
-    boolean canRenderInLayer(BlockState state, RenderType layer);
+    Set<RenderType> getExtraLayers(BlockState state);
 
     @Nullable
     TextureAtlasSprite getOverrideSprite(int tintIndex);

--- a/src/main/java/team/chisel/ctm/client/mixin/TextureScrapingMixin.java
+++ b/src/main/java/team/chisel/ctm/client/mixin/TextureScrapingMixin.java
@@ -3,6 +3,7 @@ package team.chisel.ctm.client.mixin;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.Shadow;
@@ -19,6 +20,7 @@ import team.chisel.ctm.client.util.TextureMetadataHandler;
 @Mixin(targets = {"net.minecraft.client.resources.model.ModelBakery$ModelBakerImpl"})
 public abstract class TextureScrapingMixin {
     
+    @Final
     @Shadow
     @Mutable
     private Function<Material, TextureAtlasSprite> modelTextureGetter;

--- a/src/main/java/team/chisel/ctm/client/model/AbstractCTMBakedModel.java
+++ b/src/main/java/team/chisel/ctm/client/model/AbstractCTMBakedModel.java
@@ -15,6 +15,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import net.minecraftforge.client.RenderTypeHelper;
 import org.jetbrains.annotations.NotNull;
 
 import com.google.common.base.Throwables;
@@ -165,7 +166,7 @@ public abstract class AbstractCTMBakedModel implements IDynamicBakedModel {
     private final @Nonnull BakedModel parent;
     private final @Nonnull Overrides overrides = new Overrides();
 
-    private final RenderType layer;
+    private final @Nullable RenderType layer;
     protected final List<BakedQuad> genQuads = new ArrayList<>();
     protected final ListMultimap<Direction, BakedQuad> faceQuads = ArrayListMultimap.create();
     
@@ -235,27 +236,21 @@ public abstract class AbstractCTMBakedModel implements IDynamicBakedModel {
     public ChunkRenderTypeSet getRenderTypes(@NotNull BlockState state, @NotNull RandomSource rand, @NotNull ModelData data) {
         if (this.layer != null) {
             return ChunkRenderTypeSet.union(ChunkRenderTypeSet.of(layer), getParent(rand).getRenderTypes(state, rand, data));
-        } else {
-            List<RenderType> ret = new ArrayList<>();
-            for (RenderType type : ChunkRenderTypeSet.all()) {
-                if (this.getModel().canRenderInLayer(state, type)) {
-                    ret.add(type);
-                }
-            }
-            return ChunkRenderTypeSet.union(ChunkRenderTypeSet.of(ret), getParent(rand).getRenderTypes(state, rand, data));
         }
+        ChunkRenderTypeSet extraTypes = ChunkRenderTypeSet.of(this.getModel().getExtraLayers(state));
+        return ChunkRenderTypeSet.union(extraTypes, getParent(rand).getRenderTypes(state, rand, data));
     }
 
     @Override
     public List<RenderType> getRenderTypes(ItemStack itemStack, boolean fabulous) {
-        List<RenderType> ret = new ArrayList<>();
-        ret.addAll(this.getParent().getRenderTypes(itemStack, fabulous));
+        List<RenderType> ret = new ArrayList<>(this.getParent().getRenderTypes(itemStack, fabulous));
         if (this.layer != null) {
             if (!ret.contains(layer)) {
                 ret.add(layer);
             }
         } else {
-            var type = ItemBlockRenderTypes.getRenderType(itemStack, false);
+            //Note: Uses this model as opposed to parent so that any layers added by CTM can be checked as well
+            var type = RenderTypeHelper.getFallbackItemRenderType(itemStack, this, false);
             if (!ret.contains(type)) {
                 ret.add(type);
             }
@@ -283,7 +278,7 @@ public abstract class AbstractCTMBakedModel implements IDynamicBakedModel {
     @Nonnull
     public BakedModel getParent(RandomSource rand) {
         if (getParent() instanceof WeightedBakedModel weightedBakedModel) {
-            Optional<WeightedEntry.Wrapper<BakedModel>> model = WeightedRandom.getWeightedItem(weightedBakedModel.list, Math.abs((int)rand.nextLong()) % ((WeightedBakedModel)getParent()).totalWeight);
+            Optional<WeightedEntry.Wrapper<BakedModel>> model = WeightedRandom.getWeightedItem(weightedBakedModel.list, Math.abs((int)rand.nextLong()) % weightedBakedModel.totalWeight);
             if (model.isPresent()) {
                 return model.get().getData();
             }

--- a/src/main/java/team/chisel/ctm/client/model/ModelBakedCTM.java
+++ b/src/main/java/team/chisel/ctm/client/model/ModelBakedCTM.java
@@ -19,7 +19,9 @@ import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.Direction;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.client.ChunkRenderTypeSet;
 import net.minecraftforge.client.model.data.ModelData;
+import net.minecraftforge.common.util.Lazy;
 import team.chisel.ctm.api.model.IModelCTM;
 import team.chisel.ctm.api.texture.ICTMTexture;
 import team.chisel.ctm.api.texture.ITextureContext;
@@ -30,7 +32,7 @@ import team.chisel.ctm.client.util.CTMPackReloadListener;
 @ParametersAreNonnullByDefault
 public class ModelBakedCTM extends AbstractCTMBakedModel {
     
-    public ModelBakedCTM(IModelCTM model, BakedModel parent, RenderType layer) {
+    public ModelBakedCTM(IModelCTM model, BakedModel parent, @Nullable RenderType layer) {
         super(model, parent, layer);
     }
 
@@ -42,6 +44,9 @@ public class ModelBakedCTM extends AbstractCTMBakedModel {
             parent = castParent.getParent(rand);
         }
 
+        BakedModel finalParent = parent;
+        //Only use this if state is not null
+        Lazy<ChunkRenderTypeSet> lazyParentTypes = Lazy.of(() -> finalParent.getRenderTypes(state, rand, data));
         AbstractCTMBakedModel ret = new ModelBakedCTM(model, parent, layer);
         for (Direction facing : FACINGS) {
             List<BakedQuad> parentQuads = parent.getQuads(state, facing, rand, data, null); // NOTE: We pass null here so that all quads are always returned, layer filtering is done below
@@ -77,10 +82,11 @@ public class ModelBakedCTM extends AbstractCTMBakedModel {
             // Explore optimizations to quad goal (detecting overlaps??)
             int quadGoal = ctx == null ? 1 : texturemap.values().stream().mapToInt(tex -> tex.getType().getQuadsPerSide()).max().orElse(1);
             for (Entry<BakedQuad, ICTMTexture<?>> e : texturemap.entrySet()) {
+                ICTMTexture<?> texture = e.getValue();
                 // If the layer is null, this is a wrapped vanilla texture, so passthrough the layer check to the block
-                if (layer == null || (e.getValue().getLayer() != null && e.getValue().getLayer().getRenderType() == layer) || (e.getValue().getLayer() == null && (state == null || CTMPackReloadListener.canRenderInLayerFallback(state, layer)))) {
-                    ITextureContext tcx = ctx == null ? null : ctx.getRenderContext(e.getValue());
-                    quads.addAll(e.getValue().transformQuad(e.getKey(), tcx, quadGoal));
+                if (layer == null || (texture.getLayer() != null && texture.getLayer().getRenderType() == layer) || (texture.getLayer() == null && (state == null || lazyParentTypes.get().contains(layer)))) {
+                    ITextureContext tcx = ctx == null ? null : ctx.getRenderContext(texture);
+                    quads.addAll(texture.transformQuad(e.getKey(), tcx, quadGoal));
                 }
             }
         }

--- a/src/main/java/team/chisel/ctm/client/util/CTMPackReloadListener.java
+++ b/src/main/java/team/chisel/ctm/client/util/CTMPackReloadListener.java
@@ -1,40 +1,9 @@
 package team.chisel.ctm.client.util;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.reflect.Field;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.function.Predicate;
-
-import javax.annotation.Nullable;
-
-import org.apache.commons.lang3.tuple.Pair;
-
-import com.google.common.collect.Maps;
 import com.mojang.datafixers.util.Unit;
-
-import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
-import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
-import lombok.RequiredArgsConstructor;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.ItemBlockRenderTypes;
-import net.minecraft.client.renderer.RenderType;
-import net.minecraft.client.resources.model.BakedModel;
-import net.minecraft.client.resources.model.MultiPartBakedModel;
-import net.minecraft.client.resources.model.WeightedBakedModel;
-import net.minecraft.core.Holder;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.server.packs.resources.SimplePreparableReloadListener;
 import net.minecraft.util.profiling.ProfilerFiller;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.LeavesBlock;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.client.ChunkRenderTypeSet;
-import net.minecraftforge.fml.util.ObfuscationReflectionHelper;
-import net.minecraftforge.registries.ForgeRegistries;
 import team.chisel.ctm.client.model.AbstractCTMBakedModel;
 
 public class CTMPackReloadListener extends SimplePreparableReloadListener<Unit> {
@@ -49,97 +18,5 @@ public class CTMPackReloadListener extends SimplePreparableReloadListener<Unit> 
         ResourceUtil.invalidateCaches();
         TextureMetadataHandler.INSTANCE.invalidateCaches();
         AbstractCTMBakedModel.invalidateCaches();
-//        refreshLayerHacks();
-    }
-
-    private static final Map<Holder.Reference<Block>, Predicate<RenderType>> blockRenderChecks = Maps.newHashMap();
-
-    private void refreshLayerHacks() {
-        blockRenderChecks.forEach((b, p) -> ItemBlockRenderTypes.setRenderLayer(b.get(), p));
-        blockRenderChecks.clear();
-
-        for (Block block : ForgeRegistries.BLOCKS.getValues()) {
-            BlockState state = block.defaultBlockState();
-            Predicate<RenderType> predicate = getLayerCheck(state, Minecraft.getInstance().getModelManager().getBlockModelShaper().getBlockModel(state));
-
-            if (predicate != null) {
-                blockRenderChecks.put(ForgeRegistries.BLOCKS.getDelegateOrThrow(block), getExistingRenderCheck(block)::contains);
-                ItemBlockRenderTypes.setRenderLayer(block, predicate);
-            }
-        }
-    }
-    
-    @RequiredArgsConstructor
-    private static class CachingLayerCheck implements Predicate<RenderType> {
-        
-        static <T> CachingLayerCheck of(BlockState state, Collection<T> rawModels, Function<T, BakedModel> converter) {
-            List<AbstractCTMBakedModel> ctmModels = rawModels.stream()
-                    .map(converter)
-                    .filter(m -> m instanceof AbstractCTMBakedModel)
-                    .map(m -> (AbstractCTMBakedModel) m)
-                    .toList();
-            return new CachingLayerCheck(state, ctmModels, ctmModels.size() < rawModels.size());
-        }
-        
-        private final BlockState state;
-        private final List<AbstractCTMBakedModel> models;
-        private final boolean useFallback;
-        
-        private final Object2BooleanMap<RenderType> cache = new Object2BooleanOpenHashMap<>();
-        
-        @Override
-        public boolean test(@Nullable RenderType layer) {
-            return cache.computeIfAbsent(layer, (RenderType type) -> 
-                models.stream().anyMatch(m -> m.getModel().canRenderInLayer(state, type)) ||
-                (useFallback && canRenderInLayerFallback(state, type)));
-        }
-    }
-    
-    private @Nullable Predicate<RenderType> getLayerCheck(BlockState state, BakedModel model) {
-        if (model instanceof AbstractCTMBakedModel ctmModel) {
-            return layer -> ctmModel.getModel().canRenderInLayer(state, layer);
-        }
-        if (model instanceof WeightedBakedModel weightedModel) {
-            return CachingLayerCheck.of(state, weightedModel.list, wm -> wm.getData());
-        }
-        if (model instanceof MultiPartBakedModel multiPartModel) {
-            return CachingLayerCheck.of(state, multiPartModel.selectors, Pair::getRight);
-        }
-        return null;
-    }
-
-    private static final Field _blockRenderChecks = ObfuscationReflectionHelper.findField(ItemBlockRenderTypes.class, "BLOCK_RENDER_TYPES");
-    private static final MethodHandle _fancyGraphics;
-    static {
-        try {
-            _fancyGraphics = MethodHandles.lookup().unreflectGetter(ObfuscationReflectionHelper.findField(ItemBlockRenderTypes.class, "f_109277_"));
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private ChunkRenderTypeSet getExistingRenderCheck(Block block) {
-        try {
-            return ((Map<Holder.Reference<Block>, ChunkRenderTypeSet>) _blockRenderChecks.get(null)).get(ForgeRegistries.BLOCKS.getDelegateOrThrow(block));
-        } catch (IllegalArgumentException | IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public static boolean canRenderInLayerFallback(BlockState state, RenderType type) {
-        Block block = state.getBlock();
-        if (block instanceof LeavesBlock) {
-            try {
-                return ((boolean) _fancyGraphics.invokeExact()) ? type == RenderType.cutoutMipped() : type == RenderType.solid();
-            } catch (Throwable e) {
-                throw new RuntimeException(e);
-            }
-        } else {
-            java.util.function.Predicate<RenderType> rendertype;
-            synchronized (ItemBlockRenderTypes.class) {
-                rendertype = blockRenderChecks.get(ForgeRegistries.BLOCKS.getDelegateOrThrow(block));
-            }
-            return rendertype != null ? rendertype.test(type) : type == RenderType.solid();
-        }
     }
 }

--- a/src/main/java/team/chisel/ctm/client/util/Quad.java
+++ b/src/main/java/team/chisel/ctm/client/util/Quad.java
@@ -519,12 +519,12 @@ public class Quad {
     }
     
     @SuppressWarnings("null")
-    public BakedQuad rebake() {        
-        var quad = new BakedQuad[1];
-        var builder = new QuadBakingVertexConsumer(q -> quad[0] = q);
+    public BakedQuad rebake() {
+        var builder = new QuadBakingVertexConsumer.Buffered();
         builder.setDirection(this.builder.quadOrientation);
         builder.setTintIndex(this.builder.quadTint);
         builder.setShade(this.builder.applyDiffuseLighting);
+        builder.setHasAmbientOcclusion(this.builder.applyAmbientOcclusion);
         builder.setSprite(this.uvs.getSprite());
         var format = DefaultVertexFormat.BLOCK;
         
@@ -557,7 +557,7 @@ public class Quad {
             builder.endVertex();
         }
 
-        return quad[0];
+        return builder.getQuad();
     }
     
     public Quad transformUVs(TextureAtlasSprite sprite) {
@@ -621,6 +621,9 @@ public class Quad {
 
         @Setter
         private boolean applyDiffuseLighting;
+
+        @Setter
+        private boolean applyAmbientOcclusion;
         
         private final float[][] positions = new float[4][];
         private final float[][] uvs = new float[4][];
@@ -632,6 +635,7 @@ public class Quad {
             setQuadTint(baked.getTintIndex());
             setQuadOrientation(baked.getDirection());
             setApplyDiffuseLighting(baked.isShade());
+            setApplyAmbientOcclusion(baked.hasAmbientOcclusion());
             var vertices = baked.getVertices();
             for (int i = 0; i < 4; i++) {
                 int offset = i * STRIDE;

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,15 +1,6 @@
-# canRenderInLayer hook
-# public net.minecraft.client.renderer.model.WeightedBakedModel field_177566_c baseModel
-
 # Weighted model caching hax
 public net.minecraft.client.resources.model.WeightedBakedModel f_119540_ # totalWeight
-# public net.minecraft.client.renderer.model.WeightedBakedModel field_177565_b models
 public net.minecraft.client.resources.model.WeightedBakedModel f_119541_ # list
-# public net.minecraft.client.renderer.model.WeightedBakedModel$WeightedModel
-# public net.minecraft.client.renderer.model.WeightedBakedModel$WeightedModel field_185281_b # model
-
-# Multipart model access
-public net.minecraft.client.resources.model.MultiPartBakedModel f_119459_ # selectors
 
 # ModelBakery hacks
 public net.minecraft.client.resources.model.ModelBakery$ModelBakerImpl


### PR DESCRIPTION
1.20 version of #204 while making breaking changes as there hasn't been a release of 1.20 yet.

Changes:
- Fixes crash in prod due to shadowed field not being reobf'd
- Ensure that ambient occlusion is not stripped when unbaking and rebaking quads (#202)
- Fixed always (except for leaves) including solid as a render type for baked CTM models which was causing the sugar cane CTM test resources to render with black boxes as opposed to respecting cutout
- Fixed using default render types instead of model based types for rendering the item variants of baked CTM models which was causing translucent based blocks to render incorrectly as can be seen by the pictures of the item variants in #202 
- Respect model render types for fallback in baked CTM model rather than using the broken `canRenderInLayerFallback` method
- Switched to using the helper `QuadBakingVertexConsumer.Buffered` rather than effectively reimplementing it
- Removed a lot of unused and deprecated bits of `CTMPackReloadListener` and removed corresponding no longer necessary ATs

Questions/comments:
- In `ModelCTM` the formatting displays incorrectly for one of the changes as that section of code uses a mix of tabs and spaces so I am not quite sure what formatting it is supposed to have so if you have any input let me know and I can fix it.
- I am not fully positive about the desired rendering of items for CTM so I am basically having it do what it was which is defaulting to how the base block version would render (which seems to be working fine), but figured I should ask if this should use the new `getExtraLayers` method directly or not
