### PR TITLE
Rework Quad transformations and clean up a couple things

### DIFF
--- a/src/main/java/team/chisel/ctm/client/mixin/TextureScrapingMixin.java
+++ b/src/main/java/team/chisel/ctm/client/mixin/TextureScrapingMixin.java
@@ -1,36 +1,23 @@
 package team.chisel.ctm.client.mixin;
 
-import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import org.spongepowered.asm.mixin.Final;
+import net.minecraft.client.resources.model.ModelState;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Mutable;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.model.Material;
-import net.minecraft.client.resources.model.ModelBakery;
 import net.minecraft.resources.ResourceLocation;
-import team.chisel.ctm.client.util.TextureMetadataHandler;
+import team.chisel.ctm.client.util.SpriteFunctionWrapper;
 
 @Mixin(targets = {"net.minecraft.client.resources.model.ModelBakery$ModelBakerImpl"})
 public abstract class TextureScrapingMixin {
-    
-    @Final
-    @Shadow
-    @Mutable
-    private Function<Material, TextureAtlasSprite> modelTextureGetter;
-    
-    @Inject(at = @At("TAIL"), method = "<init>")
-    private void _createWrapper(ModelBakery outer, BiFunction<ResourceLocation, Material, TextureAtlasSprite> p_249651_, ResourceLocation p_251408_, CallbackInfo callback) {
-        final var oldGetter = this.modelTextureGetter;
-        this.modelTextureGetter = (mat) -> {
-            TextureMetadataHandler.TEXTURES_SCRAPED.put(p_251408_, mat);
-            return oldGetter.apply(mat);
-        };
+
+    //Note: We don't remap this method as it is a forge added method
+    @ModifyVariable(at = @At("HEAD"), method = "bake(Lnet/minecraft/resources/ResourceLocation;Lnet/minecraft/client/resources/model/ModelState;Ljava/util/function/Function;)Lnet/minecraft/client/resources/model/BakedModel;", argsOnly = true, remap = false)
+    private Function<Material, TextureAtlasSprite> ctm_scrapeTextures(Function<Material, TextureAtlasSprite> sprites, ResourceLocation modelLocation, ModelState modelState) {
+        return new SpriteFunctionWrapper(sprites, modelLocation);
     }
 }

--- a/src/main/java/team/chisel/ctm/client/model/ModelCTM.java
+++ b/src/main/java/team/chisel/ctm/client/model/ModelCTM.java
@@ -121,11 +121,7 @@ public class ModelCTM implements IModelCTM {
         } else {
             initializeOverrides(spriteGetter);
             this.textureDependencies.forEach(t -> initializeTexture(new Material(TextureAtlas.LOCATION_BLOCKS, t), spriteGetter));
-            parent = vanillamodel.bake(bakery, mat -> {
-                var ret = spriteGetter.apply(mat);
-                initializeTexture(mat, spriteGetter);
-                return ret;
-            }, modelTransform, modelLocation);
+            parent = vanillamodel.bake(bakery, mat -> initializeTexture(mat, spriteGetter), modelTransform, modelLocation);
             if (!isInitialized()) {
                 this.spriteOverrides = new Int2ObjectOpenHashMap<>();
                 this.textureOverrides = new HashMap<>();
@@ -134,7 +130,7 @@ public class ModelCTM implements IModelCTM {
         return new ModelBakedCTM(this, parent, null);
     }
 	
-	public void initializeTexture(Material m, Function<Material, TextureAtlasSprite> spriteGetter) {
+	public TextureAtlasSprite initializeTexture(Material m, Function<Material, TextureAtlasSprite> spriteGetter) {
 	    TextureAtlasSprite sprite = spriteGetter.apply(m);
 	    Optional<IMetadataSectionCTM> chiselmeta = Optional.empty();
 	    try {
@@ -154,6 +150,7 @@ public class ModelCTM implements IModelCTM {
             }
 	        return tex;
 	    });
+        return sprite;
 	}
 	
 	private void initializeOverrides(Function<Material, TextureAtlasSprite> spriteGetter) {

--- a/src/main/java/team/chisel/ctm/client/newctm/TextureCustomCTM.java
+++ b/src/main/java/team/chisel/ctm/client/newctm/TextureCustomCTM.java
@@ -98,7 +98,7 @@ public class TextureCustomCTM<T extends TextureTypeCustom> extends AbstractTextu
         OutputFace[] ctm = ((TextureContextCustomCTM)context).getCTM(bq.getDirection()).getCachedSubmaps();
         List<BakedQuad> ret = new ArrayList<>();
         for (var face : ctm) {
-            System.out.println(bq.getDirection() + "\t" + face.getFace() + ": " + face.getTex() + "@ " + face.getUvs());
+            //System.out.println(bq.getDirection() + "\t" + face.getFace() + ": " + face.getTex() + "@ " + face.getUvs());
             Quad sub = quad.subsect(face.getFace());
             if (sub != null) {
                 ret.add(sub.setUVs(sprites[face.getTex()], face.getUvs()).rebake());

--- a/src/main/java/team/chisel/ctm/client/texture/render/TextureCTM.java
+++ b/src/main/java/team/chisel/ctm/client/texture/render/TextureCTM.java
@@ -106,7 +106,7 @@ public class TextureCTM<T extends TextureTypeCTM> extends AbstractTexture<T> {
         Quad[] quads = quad.subdivide(4);
         
         int[] ctm = ((TextureContextCTM)context).getCTM(bq.getDirection()).getSubmapIndices();
-        System.out.println(bq.getDirection() + ": " + Arrays.toString(ctm));
+        //System.out.println(bq.getDirection() + ": " + Arrays.toString(ctm));
 
         for (int i = 0; i < quads.length; i++) {
             Quad q = quads[i];

--- a/src/main/java/team/chisel/ctm/client/util/BakedQuadRetextured.java
+++ b/src/main/java/team/chisel/ctm/client/util/BakedQuadRetextured.java
@@ -2,34 +2,29 @@ package team.chisel.ctm.client.util;
 
 import java.util.Arrays;
 
-import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import net.minecraft.client.renderer.block.model.BakedQuad;
-import net.minecraft.client.renderer.block.model.FaceBakery;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.client.model.IQuadTransformer;
 
 /**
  * Revived from 1.14
  * 
  * @author Mojang
  */
-@OnlyIn(Dist.CLIENT)
 public class BakedQuadRetextured extends BakedQuad {
    private final TextureAtlasSprite texture;
 
    public BakedQuadRetextured(BakedQuad quad, TextureAtlasSprite textureIn) {
-      super(Arrays.copyOf(quad.getVertices(), quad.getVertices().length), quad.getTintIndex(), FaceBakery.calculateFacing(quad.getVertices()), quad.getSprite(), quad.isShade());
+      super(Arrays.copyOf(quad.getVertices(), quad.getVertices().length), quad.getTintIndex(), quad.getDirection(), quad.getSprite(), quad.isShade(), quad.hasAmbientOcclusion());
       this.texture = textureIn;
       this.remapQuad();
    }
 
    private void remapQuad() {
       for(int i = 0; i < 4; ++i) {
-          int j = DefaultVertexFormat.BLOCK.getIntegerSize() * i;
-          int uvIndex = 4;
-          this.vertices[j + uvIndex] = Float.floatToRawIntBits(this.texture.getU(getUnInterpolatedU(this.sprite, Float.intBitsToFloat(this.vertices[j + uvIndex]))));
-          this.vertices[j + uvIndex + 1] = Float.floatToRawIntBits(this.texture.getV(getUnInterpolatedV(this.sprite, Float.intBitsToFloat(this.vertices[j + uvIndex + 1]))));
+          int offset = i * IQuadTransformer.STRIDE + IQuadTransformer.UV0;
+          this.vertices[offset] = Float.floatToRawIntBits(this.texture.getU(getUnInterpolatedU(this.sprite, Float.intBitsToFloat(this.vertices[offset]))));
+          this.vertices[offset + 1] = Float.floatToRawIntBits(this.texture.getV(getUnInterpolatedV(this.sprite, Float.intBitsToFloat(this.vertices[offset + 1]))));
       }
    }
    

--- a/src/main/java/team/chisel/ctm/client/util/CTMPackReloadListener.java
+++ b/src/main/java/team/chisel/ctm/client/util/CTMPackReloadListener.java
@@ -17,6 +17,7 @@ public class CTMPackReloadListener extends SimplePreparableReloadListener<Unit> 
     protected void apply(Unit objectIn, ResourceManager resourceManagerIn, ProfilerFiller profilerIn) {
         ResourceUtil.invalidateCaches();
         TextureMetadataHandler.INSTANCE.invalidateCaches();
+        TextureMetadataHandler.TEXTURES_SCRAPED.clear();
         AbstractCTMBakedModel.invalidateCaches();
     }
 }

--- a/src/main/java/team/chisel/ctm/client/util/CTMPackReloadListener.java
+++ b/src/main/java/team/chisel/ctm/client/util/CTMPackReloadListener.java
@@ -17,7 +17,6 @@ public class CTMPackReloadListener extends SimplePreparableReloadListener<Unit> 
     protected void apply(Unit objectIn, ResourceManager resourceManagerIn, ProfilerFiller profilerIn) {
         ResourceUtil.invalidateCaches();
         TextureMetadataHandler.INSTANCE.invalidateCaches();
-        TextureMetadataHandler.TEXTURES_SCRAPED.clear();
         AbstractCTMBakedModel.invalidateCaches();
     }
 }

--- a/src/main/java/team/chisel/ctm/client/util/Quad.java
+++ b/src/main/java/team/chisel/ctm/client/util/Quad.java
@@ -1,36 +1,27 @@
 package team.chisel.ctm.client.util;
 
-import static net.minecraftforge.client.model.IQuadTransformer.COLOR;
-import static net.minecraftforge.client.model.IQuadTransformer.POSITION;
-import static net.minecraftforge.client.model.IQuadTransformer.STRIDE;
-import static net.minecraftforge.client.model.IQuadTransformer.UV0;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
 
-import java.util.HashMap;
-import java.util.IdentityHashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.annotation.Nullable;
+import java.util.Arrays;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.util.Mth;
+import org.jetbrains.annotations.NotNull;
 import org.joml.Vector3f;
 
 import com.google.common.base.Preconditions;
-import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormatElement;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import lombok.Value;
-import net.minecraft.Util;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
-import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Direction.Axis;
-import net.minecraft.core.Direction.AxisDirection;
 import net.minecraft.world.phys.Vec2;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.client.model.pipeline.QuadBakingVertexConsumer;
@@ -38,7 +29,7 @@ import team.chisel.ctm.api.texture.ISubmap;
 import team.chisel.ctm.api.util.NonnullType;
 
 @ParametersAreNonnullByDefault
-@ToString(of = { "vertPos", "vertUv" })
+@ToString(of = { "vertices"})
 public class Quad {
     
     @Deprecated
@@ -49,18 +40,13 @@ public class Quad {
     public static final ISubmap BOTTOM_LEFT = Submap.fromPixelScale(7.8f, 7.8f, 0, 8.2f);
     @Deprecated
     public static final ISubmap BOTTOM_RIGHT = Submap.fromPixelScale(7.8f, 7.8f, 8.2f, 8.2f);
-    
-    @Value
-    public static class Vertex {
-        Vector3f pos;
-        Vec2 uvs;
+
+    public record Vertex(Vector3f pos, Vec2 uvs) {
     }
 
-    private static final TextureAtlasSprite BASE = null;//Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS).apply(MissingTextureAtlasSprite.getLocation());
-    
     @ToString
-    public class UVs implements ISubmap {
-        
+    public static class UVs implements ISubmap {
+
         @Getter
         private float minU, minV, maxU, maxV;
         
@@ -68,11 +54,7 @@ public class Quad {
         private final TextureAtlasSprite sprite;
         
         private final Vec2[] data;
-        
-        private UVs(Vec2... data) {
-            this(BASE, data);
-        }
-        
+
         private UVs(TextureAtlasSprite sprite, Vec2... data) {
             this.data = data;
             this.sprite = sprite;
@@ -189,18 +171,9 @@ public class Quad {
         
         public int getQuadrant() {
             if (maxU <= 0.5f) {
-                if (maxV <= 0.5f) {
-                    return 3;
-                } else {
-                    return 0;
-                }
-            } else {
-                if (maxV <= 0.5f) {
-                    return 2;
-                } else {
-                    return 1;
-                }
+                return maxV <= 0.5f ? 3 : 0;
             }
+            return maxV <= 0.5f ? 2 : 1;
         }
 
         @Override
@@ -234,75 +207,55 @@ public class Quad {
         }
     }
 
-    private final Vector3f[] vertPos;
-    private final Vec2[] vertUv;
-        
+    private final VertexData[] vertices;
+
     // Technically nonfinal, but treated as such except in constructor
     @Getter
     private UVs uvs;
     
     private final Builder builder;
 
-    private final int blocklight, skylight;
-    
-    private Quad(Vector3f[] verts, Vec2[] uvs, Builder builder, TextureAtlasSprite sprite) {
-        this(verts, uvs, builder, sprite, 0, 0);
-    }
-
-    @Deprecated
-    private Quad(Vector3f[] verts, Vec2[] uvs, Builder builder, TextureAtlasSprite sprite, boolean fullbright) {
-        this(verts, uvs, builder, sprite, fullbright ? 15 : 0, fullbright ? 15 : 0);
-    }
-    
-    private Quad(Vector3f[] verts, Vec2[] uvs, Builder builder, TextureAtlasSprite sprite, int blocklight, int skylight) {
-        this.vertPos = verts;
-        this.vertUv = uvs;
+    private Quad(VertexData[] vertices, Builder builder, TextureAtlasSprite sprite) {
+        this.vertices = vertices;
         this.builder = builder;
+        Vec2[] uvs = new Vec2[this.vertices.length];
+        for (int i = 0; i < uvs.length; i++) {
+            uvs[i] = this.vertices[i].getUV();
+        }
         this.uvs = new UVs(sprite, uvs);
-        this.blocklight = blocklight;
-        this.skylight = skylight;
-    }
-    
-    @Deprecated
-    private Quad(Vector3f[] verts, UVs uvs, Builder builder) {
-        this(verts, uvs.vectorize(), builder, uvs.getSprite());
     }
 
-    @Deprecated
-    private Quad(Vector3f[] verts, UVs uvs, Builder builder, boolean fullbright) {
-        this(verts, uvs.vectorize(), builder, uvs.getSprite(), fullbright);
-    }
-    
-    private Quad(Vector3f[] verts, UVs uvs, Builder builder, int blocklight, int skylight) {
-        this(verts, uvs.vectorize(), builder, uvs.getSprite(), blocklight, skylight);
+    private VertexData[] copyVertices() {
+        VertexData[] verticesCopy = new VertexData[vertices.length];
+        for (int i = 0; i < vertices.length; i++) {
+            //Note: As we know all our vertices are made from unpacking quads we can just do a shallow copy instead of
+            // having to create a full copy of any misc data we may have
+            verticesCopy[i] = vertices[i].copy(false);
+        }
+        return verticesCopy;
     }
     
     public Vector3f getVert(int index) {
-    	return new Vector3f(vertPos[index % 4]);
+        VertexData vertex = vertices[index % vertices.length];
+        return new Vector3f((float) vertex.getPosX(), (float) vertex.getPosY(), (float) vertex.getPosZ());
     }
     
     public Quad withVert(int index, Vector3f vert) {
-        Preconditions.checkElementIndex(index, 4, "Vertex index out of range!");
-        Vector3f[] newverts = new Vector3f[4];
-        System.arraycopy(vertPos, 0, newverts, 0, newverts.length);
-        newverts[index] = vert;
-        return new Quad(newverts, getUvs(), builder, blocklight, skylight);
+        Preconditions.checkElementIndex(index, vertices.length, "Vertex index out of range!");
+        VertexData[] newVertices = copyVertices();
+        newVertices[index].pos(vert.x, vert.y, vert.z);
+        return new Quad(newVertices, builder, getUvs().getSprite());
     }
     
     public Vec2 getUv(int index) {
-    	return new Vec2(vertUv[index % 4].x, vertUv[index % 4].y);
+        return vertices[index % vertices.length].getUV();
     }
     
     public Quad withUv(int index, Vec2 uv) {
-        Preconditions.checkElementIndex(index, 4, "UV index out of range!");
-        Vec2[] newuvs = new Vec2[4];
-        System.arraycopy(getUvs().vectorize(), 0, newuvs, 0, newuvs.length);
-        newuvs[index] = uv;
-        return new Quad(vertPos, new UVs(newuvs), builder, blocklight, skylight);
-    }
-
-    public void compute() {
-
+        Preconditions.checkElementIndex(index, vertices.length, "UV index out of range!");
+        VertexData[] newVertices = copyVertices();
+        newVertices[index].texRaw(uv.x, uv.y);
+        return new Quad(newVertices, builder, getUvs().getSprite());
     }
 
     @Deprecated
@@ -337,31 +290,33 @@ public class Quad {
     public Quad subsect(ISubmap submap) {
 
         int firstIndex = 0;
-        for (int i = 0; i < vertUv.length; i++) {
-            if (vertUv[i].y == getUvs().minV && vertUv[i].x == getUvs().minU) {
+        for (int i = 0; i < vertices.length; i++) {
+            VertexData vertex = vertices[i];
+            if (vertex.getTexV() == getUvs().minV && vertex.getTexU() == getUvs().minU) {
                 firstIndex = i;
                 break;
             }
         }
-    
-        Vector3f[] positions = new Vector3f[4];
-        float[][] uvs = new float[4][];
-        for (int i = 0; i < 4; i++) {
-            int idx = (firstIndex + i) % 4;
-            positions[i] = new Vector3f(vertPos[idx]);
-            uvs[i] = new float[] { vertUv[idx].x, vertUv[idx].y };
+
+        Vec3[] positions = new Vec3[vertices.length];
+        float[][] uvs = new float[vertices.length][];
+        for (int i = 0; i < vertices.length; i++) {
+            int idx = (firstIndex + i) % vertices.length;
+            VertexData vertex = vertices[idx];
+            positions[i] = vertex.getPos();
+            uvs[i] = new float[] { vertex.getTexU(), vertex.getTexV() };
         }
-        
-        var origin = new Vec3(positions[0]);
-        var n1 = new Vec3(positions[1]).subtract(origin);
-        var n2 = new Vec3(positions[2]).subtract(origin);
+
+        var origin = positions[0];
+        var n1 = positions[1].subtract(origin);
+        var n2 = positions[2].subtract(origin);
         var normalVec = n1.cross(n2).normalize();
         Direction normal = Direction.fromDelta((int) normalVec.x, (int) normalVec.y, (int) normalVec.z);
         TextureAtlasSprite sprite = getUvs().getSprite();
-        
-        var xy = new float[4][2];
-        var newXy = new float[4][2];
-        for (int i = 0; i < 4; i++) {
+
+        var xy = new double[positions.length][2];
+        var newXy = new double[positions.length][2];
+        for (int i = 0; i < positions.length; i++) {
             switch (normal.getAxis()) {
                 case Y -> {
                     xy[i][0] = positions[i].x;
@@ -423,38 +378,23 @@ public class Quad {
         float v2Interp = normalize(xy[2][1], xy[3][1], newXy[2][1]);
         float u3Interp = normalize(xy[3][0], xy[0][0], newXy[3][0]);
         float v3Interp = normalize(xy[3][1], xy[2][1], newXy[3][1]);
-    
-        float u0 = lerp(uvs[0][0], uvs[3][0], u0Interp);
-        float v0 = lerp(uvs[0][1], uvs[1][1], v0Interp);
-        float u1 = lerp(uvs[1][0], uvs[2][0], u1Interp);
-        float v1 = lerp(uvs[1][1], uvs[0][1], v1Interp);
-        float u2 = lerp(uvs[2][0], uvs[1][0], u2Interp);
-        float v2 = lerp(uvs[2][1], uvs[3][1], v2Interp);
-        float u3 = lerp(uvs[3][0], uvs[0][0], u3Interp);
-        float v3 = lerp(uvs[3][1], uvs[2][1], v3Interp);
-    
-        var newUvs = new UVs(sprite, new Vec2(u0, v0), new Vec2(u1, v1), new Vec2(u2, v2), new Vec2(u3, v3));
-        
-        Vector3f[] newPos = new Vector3f[4];
-        for (int i = 0; i < 4; i++) {
-            newPos[i] = new Vector3f(positions[i]);
+
+        VertexData[] newVertices = copyVertices();
+        newVertices[0].texRaw(lerp(uvs[0][0], uvs[3][0], u0Interp), lerp(uvs[0][1], uvs[1][1], v0Interp));
+        newVertices[1].texRaw(lerp(uvs[1][0], uvs[2][0], u1Interp), lerp(uvs[1][1], uvs[0][1], v1Interp));
+        newVertices[2].texRaw(lerp(uvs[2][0], uvs[1][0], u2Interp), lerp(uvs[2][1], uvs[3][1], v2Interp));
+        newVertices[3].texRaw(lerp(uvs[3][0], uvs[0][0], u3Interp),  lerp(uvs[3][1], uvs[2][1], v3Interp));
+
+        for (int i = 0; i < newVertices.length; i++) {
+            VertexData newVertex = newVertices[i];
             switch (normal.getAxis()) {
-                case Y -> {
-                    newPos[i].x = newXy[i][0];
-                    newPos[i].z = newXy[i][1];
-                }
-                case Z -> {
-                    newPos[i].x = newXy[i][0];
-                    newPos[i].y = newXy[i][1];
-                }
-                case X -> {
-                    newPos[i].z = newXy[i][0];
-                    newPos[i].y = newXy[i][1];
-                }
+                case Y -> newVertex.pos(newXy[i][0], newVertex.getPosY(), newXy[i][1]);
+                case Z -> newVertex.pos(newXy[i][0], newXy[i][1], newVertex.getPosZ());
+                case X -> newVertex.pos(newVertex.getPosX(), newXy[i][1], newXy[i][0]);
             }
         }
-        
-        return new Quad(newPos, newUvs, builder, blocklight, skylight);
+
+        return new Quad(newVertices, builder, sprite);
     }
 
     public static float lerp(float a, float b, float f) {
@@ -463,59 +403,55 @@ public class Quad {
 
     public static float normalize(float min, float max, float x) {
         if (min == max) return 0.5f;
-        return (x - min) / (max - min);
+        return Mth.inverseLerp(x, min, max);
     }
-    
+
+    private static float normalize(double min, double max, double x) {
+        if (min == max) return 0.5f;
+        return (float) Mth.inverseLerp(x, min, max);
+    }
+
     public Quad rotate(int amount) {
-        Vec2[] uvs = new Vec2[4];
-
+        VertexData[] vertexCopy = copyVertices();
         TextureAtlasSprite s = getUvs().getSprite();
-
-        for (int i = 0; i < 4; i++) {
-            Vec2 normalized = new Vec2(normalize(s.getU0(), s.getU1(), vertUv[i].x), normalize(s.getV0(), s.getV1(), vertUv[i].y));
-            Vec2 uv;
+        for (VertexData vertex : vertexCopy) {
+            Vec2 normalized = new Vec2(normalize(s.getU0(), s.getU1(), vertex.getTexU()), normalize(s.getV0(), s.getV1(), vertex.getTexV()));
             switch (amount) {
-            case 1:
-                uv = new Vec2(normalized.y, 1 - normalized.x);
-                break;
-            case 2:
-                uv = new Vec2(1 - normalized.x, 1 - normalized.y);
-                break;
-            case 3:
-                uv = new Vec2(1 - normalized.y, normalized.x);
-                break;
-            default:
-                uv = new Vec2(normalized.x, normalized.y);
-                break;
+                case 1 -> vertex.texRaw(normalized.y, 1 - normalized.x);
+                case 2 -> vertex.texRaw(1 - normalized.x, 1 - normalized.y);
+                case 3 -> vertex.texRaw(1 - normalized.y, normalized.x);
+                default -> vertex.texRaw(normalized.x, normalized.y);
             }
-            uvs[i] = uv;
+            vertex.texRaw(lerp(s.getU0(), s.getU1(), vertex.getTexU()), lerp(s.getV0(), s.getV1(), vertex.getTexV()));
         }
-        
-        for (int i = 0; i < uvs.length; i++) {
-            uvs[i] = new Vec2(lerp(s.getU0(), s.getU1(), uvs[i].x), lerp(s.getV0(), s.getV1(), uvs[i].y));
-        }
-
-        return new Quad(vertPos, uvs, builder, getUvs().getSprite(), blocklight, skylight);
+        return new Quad(vertexCopy, builder, s);
     }
 
     public Quad derotate() {
         int start = 0;
-        for (int i = 0; i < 4; i++) {
-            if (vertUv[i].x <= getUvs().minU && vertUv[i].y <= getUvs().minV) {
+        for (int i = 0; i < vertices.length; i++) {
+            VertexData vertex = vertices[i];
+            if (vertex.getTexU() <= getUvs().minU && vertex.getTexV() <= getUvs().minV) {
                 start = i;
                 break;
             }
         }
-        
-        Vec2[] uvs = new Vec2[4];
-        for (int i = 0; i < 4; i++) {
-            uvs[i] = vertUv[(i + start) % 4];
+
+        VertexData[] vertexCopy = copyVertices();
+        for (int i = 0; i < vertices.length; i++) {
+            VertexData vertex = vertices[(i + start) % vertices.length];
+            vertexCopy[i].texRaw(vertex.getTexU(), vertex.getTexV());
         }
-        return new Quad(vertPos, uvs, builder, getUvs().getSprite(), blocklight, skylight);
+        return new Quad(vertexCopy, builder, getUvs().getSprite());
     }
 
-    public Quad setLight(int blocklight, int skylight) {
-        return new Quad(this.vertPos, uvs, builder, Math.max(this.blocklight, blocklight), Math.max(this.skylight, skylight));
+    public Quad setLight(int blockLight, int skyLight) {
+        VertexData[] vertexCopy = copyVertices();
+        for (VertexData vertexData : vertexCopy) {
+            //Only increase the light of the vertex, never decrease it if it is already natively emissive
+            vertexData.light(Math.max(vertexData.getBlockLight(), blockLight), Math.max(vertexData.getSkyLight(), skyLight));
+        }
+        return new Quad(vertexCopy, builder, getUvs().getSprite());
     }
     
     @SuppressWarnings("null")
@@ -526,35 +462,8 @@ public class Quad {
         builder.setShade(this.builder.applyDiffuseLighting);
         builder.setHasAmbientOcclusion(this.builder.applyAmbientOcclusion);
         builder.setSprite(this.uvs.getSprite());
-        var format = DefaultVertexFormat.BLOCK;
-        
-        for (int v = 0; v < 4; v++) {
-            for (int i = 0; i < format.getElements().size(); i++) {
-                VertexFormatElement ele = format.getElements().get(i);
-                switch (ele.getUsage()) {
-                case POSITION:
-                    Vector3f p = vertPos[v];
-                    builder.vertex(p.x(), p.y(), p.z());
-                    break;
-                /*case COLOR:
-                    builder.put(i, 35, 162, 204); Pretty things
-                    break;*/
-                case UV:
-                    if (ele.getIndex() == 2) {
-                        //Stuff for fullbright
-                        builder.uv2(blocklight * 0x10, skylight * 0x10);
-                        break;
-                    } else if (ele.getIndex() == 0) {
-                        Vec2 uv = vertUv[v];
-                        builder.uv(uv.x, uv.y);
-                        break;
-                    }
-                    // fallthrough
-                default:
-                    builder.misc(ele, this.builder.packedByElement.get(ele)[v]);
-                }
-            }
-            builder.endVertex();
+        for (VertexData vertex : vertices) {
+            vertex.write(builder);
         }
 
         return builder.getQuad();
@@ -565,11 +474,11 @@ public class Quad {
     }
     
     public Quad transformUVs(TextureAtlasSprite sprite, ISubmap submap) {
-        return new Quad(vertPos, getUvs().transform(sprite, submap), builder, blocklight, skylight);
+        return withUVs(getUvs().transform(sprite, submap));
     }
     
     public Quad setUVs(TextureAtlasSprite sprite, ISubmap submap) {
-        return new Quad(vertPos, sample(sprite, submap), builder, blocklight, skylight);
+        return withUVs(sample(sprite, submap));
     }
     
     private UVs sample(TextureAtlasSprite sprite, ISubmap submap) { 
@@ -583,16 +492,21 @@ public class Quad {
     }
 
     public Quad grow() {
-        return new Quad(vertPos, getUvs().normalizeQuadrant(), builder, blocklight, skylight);
+        return withUVs(getUvs().normalizeQuadrant());
+    }
+
+    private Quad withUVs(UVs uvs) {
+        VertexData[] vertexCopy = copyVertices();
+        Vec2[] vectorizedUVs = uvs.vectorize();
+        for (int i = 0; i < vertexCopy.length; i++) {
+            vertexCopy[i].texRaw(vectorizedUVs[i].x, vectorizedUVs[i].y);
+        }
+        return new Quad(vertexCopy, builder, uvs.getSprite());
     }
 
     @Deprecated
-    public Quad setFullbright(boolean fullbright){
-        if (this.blocklight == 15 != fullbright || this.skylight == 15 != fullbright) {
-            return new Quad(vertPos, getUvs(), builder, fullbright);
-        } else {
-            return this;
-        }
+    public Quad setFullbright(boolean fullbright) {
+        return fullbright ? setLight(15, 15) : this;
     }
     
     public static Quad from(BakedQuad baked) {
@@ -602,14 +516,8 @@ public class Quad {
     }
     
     @RequiredArgsConstructor
-    public static class Builder {
-        
-        private final Map<VertexFormatElement, Integer> ELEMENT_OFFSETS = Util.make(new IdentityHashMap<>(), map -> {
-            int i = 0;
-            for (var element : DefaultVertexFormat.BLOCK.getElements())
-                map.put(element, DefaultVertexFormat.BLOCK.getOffset(i++) / 4); // Int offset
-        });
-        
+    public static class Builder implements VertexConsumer {
+
         @Getter
         private final TextureAtlasSprite sprite;
 
@@ -624,72 +532,87 @@ public class Quad {
 
         @Setter
         private boolean applyAmbientOcclusion;
-        
-        private final float[][] positions = new float[4][];
-        private final float[][] uvs = new float[4][];
-        private final int[][] colors = new int[4][];
-        
-        private Map<VertexFormatElement, int[][]> packedByElement = new HashMap<>();
-                
+
+        private final VertexData[] vertices = new VertexData[4];
+        private VertexData vertex = new VertexData();
+        private int vertexIndex = 0;
+
         public void copyFrom(BakedQuad baked) {
             setQuadTint(baked.getTintIndex());
             setQuadOrientation(baked.getDirection());
             setApplyDiffuseLighting(baked.isShade());
             setApplyAmbientOcclusion(baked.hasAmbientOcclusion());
-            var vertices = baked.getVertices();
-            for (int i = 0; i < 4; i++) {
-                int offset = i * STRIDE;
-                this.positions[i] = new float[] {
-                    Float.intBitsToFloat(vertices[offset + POSITION]),
-                    Float.intBitsToFloat(vertices[offset + POSITION + 1]),
-                    Float.intBitsToFloat(vertices[offset + POSITION + 2]),
-                    0
-                };
-                int packedColor = vertices[offset + COLOR];
-                this.colors[i] = new int[] {
-                    packedColor & 0xFF,
-                    (packedColor << 8) & 0xFF,
-                    (packedColor << 16) & 0xFF,
-                    (packedColor << 24) & 0xFF
-                };
-                this.uvs[i] = new float[] {
-                   Float.intBitsToFloat(vertices[offset + UV0]),
-                   Float.intBitsToFloat(vertices[offset + UV0 + 1])
-                };
-            }
-            for (var e : ELEMENT_OFFSETS.entrySet()) {
-                var offset = e.getValue();
-                int[][] data = new int[4][e.getKey().getByteSize() / 4];
-                for (int v = 0; v < 4; v++) {
-                    for (int i = 0; i < data[v].length; i++) {
-                        data[v][i] = vertices[v * STRIDE + offset + i];
-                    }
-                }
-                this.packedByElement.put(e.getKey(), data);//new int[] { vertices[0 * STRIDE + offset], vertices[1 * STRIDE + offset], vertices[2 * STRIDE + offset], vertices[3 * STRIDE + offset]});
-            }
+            putBulkData(new PoseStack().last(), baked, 1, 1, 1, 1, 0, OverlayTexture.NO_OVERLAY, true);
         }
 
         public Quad build() {
-            Vector3f[] verts = new Vector3f[4];
-            Vec2[] uvs = new Vec2[4];
-            for (int i = 0; i < verts.length; i++) {
-                verts[i] = new Vector3f(this.positions[i][0], this.positions[i][1], this.positions[i][2]);
-                uvs[i] = new Vec2(this.uvs[i][0], this.uvs[i][1]);
-            }
-            // TODO need to extract light data here
-            return new Quad(verts, uvs, this, getSprite());
+            return new Quad(vertices, this, getSprite());
         }
 
-        @SuppressWarnings("unchecked")
-        private <T> T[] fromData(List<float[]> data, int size) {
-            Object[] ret = size == 2 ? new Vec2[data.size()] : new Vector3f[data.size()];
-            for (int i = 0; i < data.size(); i++) {
-                ret[i] = size == 2 ? new Vec2(data.get(i)[0], data.get(i)[1]) : new Vector3f(data.get(i)[0], data.get(i)[1], data.get(i)[2]);
-            }
-            return (T[]) ret;
+        @NotNull
+        @Override
+        public VertexConsumer vertex(double x, double y, double z) {
+            vertex.pos(x, y, z);
+            return this;
         }
-        
-        //@Override //soft override, only exists in new forge versions
-        public void setTexture(@Nullable TextureAtlasSprite texture) {}
+
+        @NotNull
+        @Override
+        public VertexConsumer color(int red, int green, int blue, int alpha) {
+            vertex.color(red, green, blue, alpha);
+            return this;
+        }
+
+        @NotNull
+        @Override
+        public VertexConsumer uv(float u, float v) {
+            vertex.texRaw(u, v);
+            return this;
+        }
+
+        @NotNull
+        @Override
+        public VertexConsumer overlayCoords(int u, int v) {
+            vertex.overlay(u, v);
+            return this;
+        }
+
+        @NotNull
+        @Override
+        public VertexConsumer uv2(int u, int v) {
+            vertex.lightRaw(u, v);
+            return this;
+        }
+
+        @NotNull
+        @Override
+        public VertexConsumer normal(float x, float y, float z) {
+            vertex.normal(x, y, z);
+            return this;
+        }
+
+        @Override
+        public void endVertex() {
+            if (vertexIndex < vertices.length) {
+                vertices[vertexIndex++] = vertex;
+                vertex = new VertexData();
+            }
+        }
+
+        @Override
+        public void defaultColor(int red, int green, int blue, int alpha) {
+            //We don't support having a default color
+        }
+
+        @Override
+        public void unsetDefaultColor() {
+            //We don't support having a default color
+        }
+
+        @Override
+        public VertexConsumer misc(VertexFormatElement element, int... rawData) {
+            vertex.misc(element, Arrays.copyOf(rawData, rawData.length));
+            return this;
+        }
     }
 }

--- a/src/main/java/team/chisel/ctm/client/util/ResourceUtil.java
+++ b/src/main/java/team/chisel/ctm/client/util/ResourceUtil.java
@@ -24,10 +24,10 @@ public class ResourceUtil {
     
     public static ResourceLocation spriteToAbsolute(ResourceLocation sprite) {
         if (!sprite.getPath().startsWith("textures/")) {
-            sprite = new ResourceLocation(sprite.getNamespace(), "textures/" + sprite.getPath());
+            sprite = sprite.withPrefix("textures/");
         }
         if (!sprite.getPath().endsWith(".png")) {
-            sprite = new ResourceLocation(sprite.getNamespace(), sprite.getPath() + ".png");
+            sprite = sprite.withSuffix(".png");
         }
         return sprite;
     }

--- a/src/main/java/team/chisel/ctm/client/util/SpriteFunctionWrapper.java
+++ b/src/main/java/team/chisel/ctm/client/util/SpriteFunctionWrapper.java
@@ -1,0 +1,27 @@
+package team.chisel.ctm.client.util;
+
+import java.util.function.Function;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.resources.model.Material;
+import net.minecraft.resources.ResourceLocation;
+
+public class SpriteFunctionWrapper implements Function<Material, TextureAtlasSprite> {
+
+    private final Function<Material, TextureAtlasSprite> internal;
+    private final ResourceLocation modelLocation;
+
+    public SpriteFunctionWrapper(Function<Material, TextureAtlasSprite> internal, ResourceLocation modelLocation) {
+        if (internal instanceof SpriteFunctionWrapper wrapper) {
+            this.internal = wrapper.internal;
+        } else {
+            this.internal = internal;
+        }
+        this.modelLocation = modelLocation;
+    }
+
+    @Override
+    public TextureAtlasSprite apply(Material material) {
+        TextureMetadataHandler.INSTANCE.textureScraped(modelLocation, material);
+        return internal.apply(material);
+    }
+}

--- a/src/main/java/team/chisel/ctm/client/util/TextureMetadataHandler.java
+++ b/src/main/java/team/chisel/ctm/client/util/TextureMetadataHandler.java
@@ -6,7 +6,6 @@ import java.util.Deque;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 
 import javax.annotation.Nonnull;
 
@@ -18,7 +17,6 @@ import com.google.common.collect.Multimap;
 import it.unimi.dsi.fastutil.objects.Object2BooleanLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
 import lombok.SneakyThrows;
-import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.client.resources.model.BlockModelRotation;
 import net.minecraft.client.resources.model.Material;
@@ -41,6 +39,11 @@ public enum TextureMetadataHandler {
 	
 	private final Set<ResourceLocation> registeredTextures = new HashSet<>();
 	private final Object2BooleanMap<ResourceLocation> wrappedModels = new Object2BooleanLinkedOpenHashMap<>();
+    private final Multimap<ResourceLocation, Material> scrapedTextures = HashMultimap.create();
+
+    public void textureScraped(ResourceLocation modelLocation, Material material) {
+        scrapedTextures.put(modelLocation, material);
+    }
     
     /*
      * Handle stitching metadata additional textures
@@ -105,8 +108,6 @@ public enum TextureMetadataHandler {
 //        }
 //    }
 
-	public static final Multimap<ResourceLocation, Material> TEXTURES_SCRAPED = HashMultimap.create();
-
     @SubscribeEvent(priority = EventPriority.LOWEST) // low priority to capture all event-registered models
     @SneakyThrows
     public void onModelBake(ModelEvent.ModifyBakingResult event) {
@@ -139,7 +140,7 @@ public enum TextureMetadataHandler {
                     }
 
                     try {
-                        Set<Material> textures = new HashSet<>(TEXTURES_SCRAPED.get(dep));
+                        Set<Material> textures = new HashSet<>(scrapedTextures.get(dep));
                         for (Material tex : textures) {
                             // Cache all dependent texture metadata
                             try {
@@ -188,17 +189,19 @@ public enum TextureMetadataHandler {
             if (e.getValue() instanceof AbstractCTMBakedModel baked && 
                     baked.getModel() instanceof ModelCTM ctmModel && 
                     !ctmModel.isInitialized()) {
-                Function<Material, TextureAtlasSprite> spriteGetter = (m) -> event.getModelManager().getAtlas(m.atlasLocation()).getSprite(m.texture());
-                var baker = ModelBakerImplAccessor.createImpl(event.getModelBakery(), ($, m) -> spriteGetter.apply(m), e.getKey());
-                ctmModel.bake(baker, spriteGetter, BlockModelRotation.X0_Y0, e.getKey()); 
+                var baker = ModelBakerImplAccessor.createImpl(event.getModelBakery(), ($, m) -> m.sprite(), e.getKey());
+                ctmModel.bake(baker, Material::sprite, BlockModelRotation.X0_Y0, e.getKey());
+                //Note: We have to clear the cache after baking each model to ensure that we can initialize and capture any textures
+                // that might be done by parent models
+                cache.clear();
             }
         }
-        cache.clear();
         cache.putAll(cacheCopy);
     }
 
     public void invalidateCaches() {
         registeredTextures.clear();
         wrappedModels.clear();
+        scrapedTextures.clear();
     }
 }

--- a/src/main/java/team/chisel/ctm/client/util/TextureMetadataHandler.java
+++ b/src/main/java/team/chisel/ctm/client/util/TextureMetadataHandler.java
@@ -14,12 +14,10 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Sets;
 
 import it.unimi.dsi.fastutil.objects.Object2BooleanLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
 import lombok.SneakyThrows;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.client.resources.model.BlockModelRotation;
@@ -36,7 +34,6 @@ import team.chisel.ctm.client.mixin.ModelBakerImplAccessor;
 import team.chisel.ctm.client.model.AbstractCTMBakedModel;
 import team.chisel.ctm.client.model.ModelBakedCTM;
 import team.chisel.ctm.client.model.ModelCTM;
-import team.chisel.ctm.client.texture.IMetadataSectionCTM;
 
 public enum TextureMetadataHandler {
 
@@ -109,15 +106,17 @@ public enum TextureMetadataHandler {
 //    }
 
 	public static final Multimap<ResourceLocation, Material> TEXTURES_SCRAPED = HashMultimap.create();
-    @SuppressWarnings("unchecked")
+
     @SubscribeEvent(priority = EventPriority.LOWEST) // low priority to capture all event-registered models
     @SneakyThrows
     public void onModelBake(ModelEvent.ModifyBakingResult event) {
         Map<ResourceLocation, UnbakedModel> stateModels = ObfuscationReflectionHelper.getPrivateValue(ModelBakery.class, event.getModelBakery(), "f_119212_");
-        for (ResourceLocation rl : event.getModels().keySet()) {
+        Map<ResourceLocation, BakedModel> models = event.getModels();
+        for (Map.Entry<ResourceLocation, BakedModel> entry : models.entrySet()) {
+            ResourceLocation rl = entry.getKey();
             UnbakedModel rootModel = stateModels.get(rl);
             if (rootModel != null) {
-            	BakedModel baked = event.getModels().get(rl);
+            	BakedModel baked = entry.getValue();
             	if (baked instanceof AbstractCTMBakedModel) {
             		continue;
             	}
@@ -140,40 +139,22 @@ public enum TextureMetadataHandler {
                     }
 
                     try {
-                        Set<Material> textures = Sets.newHashSet(TEXTURES_SCRAPED.get(dep));
-                    // FORGE WHY
-//                    if (vanillaModelWrapperClass.isAssignableFrom(model.getClass())) {
-//                        BlockModel parent = ((BlockModel) modelWrapperModel.get(model)).parent;
-//                        while (parent != null) {
-//                            textures.addAll(parent.textures.values().stream().filter(e -> e.left().isPresent()).map(e -> e.left().orElseThrow(IllegalStateException::new)).collect(Collectors.toSet()));
-//                            parent = parent.parent;
-//                        }
-//                    }
-                    
-                        Set<ResourceLocation> newDependencies = Sets.newHashSet(model.getDependencies());
-                        
-                    // FORGE WHYYYYY
-//                    if (multipartModelClass.isAssignableFrom(model.getClass())) {
-//                        Map<?, IUnbakedModel> partModels = (Map<?, IUnbakedModel>) multipartPartModels.get(model);
-//                        textures = partModels.values().stream().map(m -> m.getTextures(event.getModelLoader()::getUnbakedModel, Sets.newHashSet())).flatMap(Collection::stream).collect(Collectors.toSet());
-//                        newDependencies.addAll(partModels.values().stream().flatMap(m -> m.getDependencies().stream()).collect(Collectors.toList()));
-//                    }
-
+                        Set<Material> textures = new HashSet<>(TEXTURES_SCRAPED.get(dep));
                         for (Material tex : textures) {
-                            IMetadataSectionCTM meta = null;
                             // Cache all dependent texture metadata
                             try {
-                                meta = ResourceUtil.getMetadata(ResourceUtil.spriteToAbsolute(tex.texture())).orElse(null); // TODO lazy
-                            } catch (IOException e) {} // Fallthrough
-                            if (meta != null) {
                                 // At least one texture has CTM metadata, so we should wrap this model
-                                shouldWrap = true;
-                            }
+                                if (ResourceUtil.getMetadata(ResourceUtil.spriteToAbsolute(tex.texture())).isPresent()) { // TODO lazy
+                                    shouldWrap = true;
+                                    break;
+                                }
+                            } catch (IOException e) {} // Fallthrough
                         }
-                        
-                        for (ResourceLocation newDep : newDependencies) {
-                            if (seenModels.add(newDep)) {
-                                dependencies.push(newDep);
+                        if (!shouldWrap) {
+                            for (ResourceLocation newDep : model.getDependencies()) {
+                                if (seenModels.add(newDep)) {
+                                    dependencies.push(newDep);
+                                }
                             }
                         }
                     } catch (Exception e) {
@@ -183,8 +164,7 @@ public enum TextureMetadataHandler {
                 wrappedModels.put(rl, shouldWrap);
                 if (shouldWrap) {
                     try {
-                        event.getModels().put(rl, wrap(rootModel, baked));
-                        dependencies.clear();
+                        entry.setValue(wrap(rootModel, baked));
                     } catch (IOException e) {
                         CTM.logger.error("Could not wrap model " + rl + ". Aborting...", e);
                     }
@@ -208,7 +188,7 @@ public enum TextureMetadataHandler {
             if (e.getValue() instanceof AbstractCTMBakedModel baked && 
                     baked.getModel() instanceof ModelCTM ctmModel && 
                     !ctmModel.isInitialized()) {
-                Function<Material, TextureAtlasSprite> spriteGetter = (m) -> Minecraft.getInstance().getModelManager().getAtlas(m.atlasLocation()).getSprite(m.texture());
+                Function<Material, TextureAtlasSprite> spriteGetter = (m) -> event.getModelManager().getAtlas(m.atlasLocation()).getSprite(m.texture());
                 var baker = ModelBakerImplAccessor.createImpl(event.getModelBakery(), ($, m) -> spriteGetter.apply(m), e.getKey());
                 ctmModel.bake(baker, spriteGetter, BlockModelRotation.X0_Y0, e.getKey()); 
             }

--- a/src/main/java/team/chisel/ctm/client/util/VertexData.java
+++ b/src/main/java/team/chisel/ctm/client/util/VertexData.java
@@ -5,13 +5,17 @@ import com.mojang.blaze3d.vertex.VertexFormatElement;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 import net.minecraft.world.phys.Vec2;
 import net.minecraft.world.phys.Vec3;
 
 @Getter
 @ToString
+@NoArgsConstructor
+@AllArgsConstructor
 public class VertexData {
 
     private double posX, posY, posZ;
@@ -27,32 +31,7 @@ public class VertexData {
     // 0 to 0xF0
     private int lightU, lightV;
 
-    private final Map<VertexFormatElement, int[]> miscData;
-
-    public VertexData() {
-        this.miscData = new HashMap<>();
-    }
-
-    private VertexData(double posX, double posY, double posZ, float normalX, float normalY, float normalZ, int red, int green, int blue, int alpha, float texU, float texV,
-          int overlayU, int overlayV, int lightU, int lightV, Map<VertexFormatElement, int[]> miscData) {
-        this.posX = posX;
-        this.posY = posY;
-        this.posZ = posZ;
-        this.normalX = normalX;
-        this.normalY = normalY;
-        this.normalZ = normalZ;
-        this.red = red;
-        this.green = green;
-        this.blue = blue;
-        this.alpha = alpha;
-        this.texU = texU;
-        this.texV = texV;
-        this.overlayU = overlayU;
-        this.overlayV = overlayV;
-        this.lightU = lightU;
-        this.lightV = lightV;
-        this.miscData = miscData;
-    }
+    private Map<VertexFormatElement, int[]> miscData = new HashMap<>();
 
     public Vec3 getPos() {
         return new Vec3(posX, posY, posZ);

--- a/src/main/java/team/chisel/ctm/client/util/VertexData.java
+++ b/src/main/java/team/chisel/ctm/client/util/VertexData.java
@@ -1,0 +1,148 @@
+package team.chisel.ctm.client.util;
+
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.mojang.blaze3d.vertex.VertexFormatElement;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Getter;
+import lombok.ToString;
+import net.minecraft.world.phys.Vec2;
+import net.minecraft.world.phys.Vec3;
+
+@Getter
+@ToString
+public class VertexData {
+
+    private double posX, posY, posZ;
+    private float normalX, normalY, normalZ;
+
+    //Store int representations of the colors so that we don't go between ints and doubles when unpacking and repacking a vertex
+    private int red, green, blue, alpha;
+
+    // 0 to 16
+    private float texU, texV;
+    // 0 to 0xF0
+    private int overlayU, overlayV;
+    // 0 to 0xF0
+    private int lightU, lightV;
+
+    private final Map<VertexFormatElement, int[]> miscData;
+
+    public VertexData() {
+        this.miscData = new HashMap<>();
+    }
+
+    private VertexData(double posX, double posY, double posZ, float normalX, float normalY, float normalZ, int red, int green, int blue, int alpha, float texU, float texV,
+          int overlayU, int overlayV, int lightU, int lightV, Map<VertexFormatElement, int[]> miscData) {
+        this.posX = posX;
+        this.posY = posY;
+        this.posZ = posZ;
+        this.normalX = normalX;
+        this.normalY = normalY;
+        this.normalZ = normalZ;
+        this.red = red;
+        this.green = green;
+        this.blue = blue;
+        this.alpha = alpha;
+        this.texU = texU;
+        this.texV = texV;
+        this.overlayU = overlayU;
+        this.overlayV = overlayV;
+        this.lightU = lightU;
+        this.lightV = lightV;
+        this.miscData = miscData;
+    }
+
+    public Vec3 getPos() {
+        return new Vec3(posX, posY, posZ);
+    }
+
+    public Vec2 getUV() {
+        return new Vec2(texU, texV);
+    }
+
+    public int getBlockLight() {
+        return lightU >> 4;
+    }
+
+    public int getSkyLight() {
+        return lightV >> 4;
+    }
+
+    public VertexData color(int red, int green, int blue, int alpha) {
+        this.red = red;
+        this.green = green;
+        this.blue = blue;
+        this.alpha = alpha;
+        return this;
+    }
+
+    public VertexData pos(double x, double y, double z) {
+        this.posX = x;
+        this.posY = y;
+        this.posZ = z;
+        return this;
+    }
+
+    public VertexData normal(float x, float y, float z) {
+        this.normalX = x;
+        this.normalY = y;
+        this.normalZ = z;
+        return this;
+    }
+
+    public VertexData texRaw(float u, float v) {
+        texU = u;
+        texV = v;
+        return this;
+    }
+
+    public VertexData overlay(int u, int v) {
+        overlayU = u;
+        overlayV = v;
+        return this;
+    }
+
+    public VertexData lightRaw(int u, int v) {
+        lightU = u;
+        lightV = v;
+        return this;
+    }
+
+    public VertexData light(int u, int v) {
+        return lightRaw(u << 4, v << 4);
+    }
+
+    public VertexData misc(VertexFormatElement element, int... data) {
+        miscData.put(element, data);
+        return this;
+    }
+
+    public VertexData copy(boolean deepCopy) {
+        Map<VertexFormatElement, int[]> miscCopy;
+        if (deepCopy) {
+            //Deep copy the misc data
+            miscCopy = new HashMap<>();
+            for (Map.Entry<VertexFormatElement, int[]> entry : miscData.entrySet()) {
+                miscCopy.put(entry.getKey(), Arrays.copyOf(entry.getValue(), entry.getValue().length));
+            }
+        } else {
+            miscCopy = miscData;
+        }
+        return new VertexData(posX, posY, posZ, normalX, normalY, normalZ, red, green, blue, alpha, texU, texV, overlayU, overlayV, lightU, lightV, miscCopy);
+    }
+
+    public void write(VertexConsumer consumer) {
+        consumer.vertex(posX, posY, posZ);
+        consumer.color(red, green, blue, alpha);
+        consumer.uv(texU, texV);
+        consumer.overlayCoords(overlayU, overlayV);
+        consumer.uv2(lightU, lightV);
+        consumer.normal(normalX, normalY, normalZ);
+        for (Map.Entry<VertexFormatElement, int[]> entry : miscData.entrySet()) {
+            consumer.misc(entry.getKey(), entry.getValue());
+        }
+        consumer.endVertex();
+    }
+}


### PR DESCRIPTION
- Reworked how `BakedQuad`s are converted into `Quad`s and then rebaked into `BakedQuad`s. This fixes lighting from models such as by using `forge_data` to ensure we don't lose the data
- Changed/fixed `Quad#setFullBright(false)` causing lighting data to be stripped by only allowing using fullbright to enable quad emissions
- Made `Quad#withUv` use current sprite instead of stripping the sprite
- Commented out a couple debug `System.out` calls
- Made `BakedQuadRetextured` persist ambient occlusion state and just query the source quad for the direction rather than recalculating it
- Fix scraping textures not associating the scraped texture with the correct model (fixes the test pack for sugar cane rendering)
- Clear scraped texture cache when reloading as it is done being used
- Make use of map entries when modifying and wrapping models to avoid extra cycles for lookups during getting and replacing
- Exit quicker when viewing a models deps and finding that it has a CTM texture. One note is that theoretically in 1.20 we should be using `UnbakedModel#resolveParents` rather than `UnbakedModel#getDependencies` to make sure it properly can hit all the child deps for models that have custom loaders... but that adds extra overhead and makes it harder (requiring exceptions as control flow) to exit early once a child model with a ctm texture is found