### PR TITLE
Various fixes/improvements to baked CTM models

### DIFF
--- a/src/main/java/team/chisel/ctm/client/model/AbstractCTMBakedModel.java
+++ b/src/main/java/team/chisel/ctm/client/model/AbstractCTMBakedModel.java
@@ -282,7 +282,8 @@ public abstract class AbstractCTMBakedModel extends BakedModelWrapper<BakedModel
         //Add any extra model data the parent model may be expecting or want to add
         tileData = super.getModelData(world, pos, state, tileData);
     	if (!tileData.has(CTM_CONTEXT)) {
-    		tileData = tileData.derive().with(CTM_CONTEXT, new CTMContext(world, pos)).build();
+    		//Ensure the position is immutable in case another mod persists the model data longer than the position
+    		tileData = tileData.derive().with(CTM_CONTEXT, new CTMContext(world, pos.immutable())).build();
     	}
     	return tileData;
     }


### PR DESCRIPTION
- Made AbstractCTMBakedModel extends BakedModelWrapper instead of implement IDynamicBakedModel and remove redundant proxying
- Pass the layer that we have stored when proxying calls to getQuads(BlockState, Direction, RandomSource) to the overload with ModelData, and RenderType
- Replace a couple use cases of `getParent(RandomSource)` with calling super and allowing the `WeightedBakedModel` implementation of said methods to handle calculating which model to use
- Allow the wrapped model to add to the model data
- Proxy both `getParticleIcon` methods
- Cache whether the parent's layers contain the layer and also have some fallback logic to attempt to determine if it is an item render type that is being passed in. This fixes an issue for mods that try to render the json block model as part of their ISBER as they will be passing render types gotten from `getRenderTypes(ItemStack, boolean)`