### PR TITLE
Implement support for IForgeBlock#getAppearance

### DIFF
--- a/src/main/java/team/chisel/ctm/api/IFacade.java
+++ b/src/main/java/team/chisel/ctm/api/IFacade.java
@@ -5,13 +5,17 @@ import javax.annotation.Nullable;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 
 /**
  * To be implemented on blocks that "hide" another block inside, so connected textures can still be accomplished.
+ * 
+ * @deprecated Implement {@link net.minecraftforge.common.extensions.IForgeBlock#getAppearance(BlockState, BlockAndTintGetter, BlockPos, Direction, BlockState, BlockPos)}
  */
+@Deprecated
 public interface IFacade {
     
     /**

--- a/src/main/java/team/chisel/ctm/api/texture/IContextProvider.java
+++ b/src/main/java/team/chisel/ctm/api/texture/IContextProvider.java
@@ -3,7 +3,7 @@ package team.chisel.ctm.api.texture;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 
 @ParametersAreNonnullByDefault
@@ -23,7 +23,7 @@ public interface IContextProvider {
      *            The current {@link ICTMTexture} being rendered.
      * @return A context which can be used to manipulate quads later in the pipeline.
      */
-    ITextureContext getBlockRenderContext(BlockState state, BlockGetter world, BlockPos pos, ICTMTexture<?> tex);
+    ITextureContext getBlockRenderContext(BlockState state, BlockAndTintGetter world, BlockPos pos, ICTMTexture<?> tex);
 
     /**
      * Recreates a render context compressed data.

--- a/src/main/java/team/chisel/ctm/api/util/RenderContextList.java
+++ b/src/main/java/team/chisel/ctm/api/util/RenderContextList.java
@@ -12,7 +12,7 @@ import com.google.common.collect.Maps;
 import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import it.unimi.dsi.fastutil.objects.Object2LongOpenCustomHashMap;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import team.chisel.ctm.api.texture.ICTMTexture;
 import team.chisel.ctm.api.texture.ITextureContext;
@@ -33,9 +33,9 @@ public class RenderContextList {
     private final Map<ICTMTexture<?>, ITextureContext> contextMap = Maps.newIdentityHashMap();
     private final Object2LongMap<ICTMTexture<?>> serialized = new Object2LongOpenCustomHashMap<>(new IdentityStrategy<>());
 
-    public RenderContextList(BlockState state, Collection<ICTMTexture<?>> textures, final BlockGetter world, BlockPos pos) {
+    public RenderContextList(BlockState state, Collection<ICTMTexture<?>> textures, final BlockAndTintGetter world, BlockPos pos) {
         ProfileUtil.start("ctm_region_cache_update");
-        BlockGetter cachedWorld = regionMetaCache.get().updateWorld(world);
+        BlockAndTintGetter cachedWorld = regionMetaCache.get().updateWorld(world);
     	
     	ProfileUtil.endAndStart("ctm_context_gather");
         for (ICTMTexture<?> tex : textures) {

--- a/src/main/java/team/chisel/ctm/client/newctm/ConnectionCheck.java
+++ b/src/main/java/team/chisel/ctm/client/newctm/ConnectionCheck.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import team.chisel.ctm.Configurations;
 import team.chisel.ctm.api.IFacade;
@@ -40,7 +40,7 @@ public class ConnectionCheck {
      *            The {@link Direction side} of the block to check for connection status. This is <i>not</i> the direction to check in.
      * @return True if the given block can connect to the given location on the given side.
      */
-    public final boolean isConnected(BlockGetter world, BlockPos current, BlockPos connection, Direction dir) {
+    public final boolean isConnected(BlockAndTintGetter world, BlockPos current, BlockPos connection, Direction dir) {
 
         BlockState state = getConnectionState(world, current, dir, connection);
         return isConnected(world, current, connection, dir, state);
@@ -61,7 +61,7 @@ public class ConnectionCheck {
      * @return True if the given block can connect to the given location on the given side.
      */
     @SuppressWarnings({ "unused", "null" })
-    public boolean isConnected(BlockGetter world, BlockPos current, BlockPos connection, Direction dir, BlockState state) {
+    public boolean isConnected(BlockAndTintGetter world, BlockPos current, BlockPos connection, Direction dir, BlockState state) {
 
 //      if (CTMLib.chiselLoaded() && connectionBlocked(world, x, y, z, dir.ordinal())) {
 //          return false;
@@ -104,10 +104,12 @@ public class ConnectionCheck {
 //        return false;
 //    }
 
-    public BlockState getConnectionState(BlockGetter world, BlockPos pos, @Nullable Direction side, BlockPos connection) {
+    public BlockState getConnectionState(BlockAndTintGetter world, BlockPos pos, @Nullable Direction side, BlockPos connection) {
         BlockState state = world.getBlockState(pos);
         if (state.getBlock() instanceof IFacade facade) {
             return facade.getFacade(world, pos, side, connection);
+        } else if (side != null) {
+            return state.getAppearance(world, pos, side, world.getBlockState(connection), connection);
         }
         return state;
     }

--- a/src/main/java/team/chisel/ctm/client/newctm/CustomCTMLogic.java
+++ b/src/main/java/team/chisel/ctm/client/newctm/CustomCTMLogic.java
@@ -10,7 +10,7 @@ import com.google.common.annotations.VisibleForTesting;
 import lombok.RequiredArgsConstructor;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.BlockAndTintGetter;
 import team.chisel.ctm.api.texture.ISubmap;
 import team.chisel.ctm.client.newctm.CTMLogicBakery.OutputFace;
 
@@ -48,14 +48,14 @@ public class CustomCTMLogic implements ICTMLogic {
         }
 
         @Override
-        public void buildConnectionMap(BlockGetter world, BlockPos pos, Direction side) {
+        public void buildConnectionMap(BlockAndTintGetter world, BlockPos pos, Direction side) {
             this.cachedSubmapIds = CustomCTMLogic.this.getSubmapIds(world, pos, side);
             this.cachedSubmaps = CustomCTMLogic.this.getSubmaps(world, pos, side);
         }
     }
 
     @Override
-    public int[] getSubmapIds(BlockGetter world, BlockPos pos, Direction side) {
+    public int[] getSubmapIds(BlockAndTintGetter world, BlockPos pos, Direction side) {
         int key = 0;
         for (int i = 0; i < directions.length; i++) {
             BlockPos conPos = pos.offset(directions[i].getOffset(side));
@@ -69,7 +69,7 @@ public class CustomCTMLogic implements ICTMLogic {
     }
 
     @Override
-    public OutputFace[] getSubmaps(BlockGetter world, BlockPos pos, Direction side) {
+    public OutputFace[] getSubmaps(BlockAndTintGetter world, BlockPos pos, Direction side) {
         var tileIds = getSubmapIds(world, pos, side);
         OutputFace[] ret = new OutputFace[tileIds.length];
         for (int i = 0; i < ret.length; i++) {

--- a/src/main/java/team/chisel/ctm/client/newctm/ICTMLogic.java
+++ b/src/main/java/team/chisel/ctm/client/newctm/ICTMLogic.java
@@ -4,15 +4,15 @@ import java.util.List;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.BlockAndTintGetter;
 import team.chisel.ctm.api.texture.ISubmap;
 import team.chisel.ctm.client.newctm.CTMLogicBakery.OutputFace;
 
 public interface ICTMLogic {
     
-    int[] getSubmapIds(BlockGetter world, BlockPos pos, Direction side);
+    int[] getSubmapIds(BlockAndTintGetter world, BlockPos pos, Direction side);
     
-    OutputFace[] getSubmaps(BlockGetter world, BlockPos pos, Direction side);
+    OutputFace[] getSubmaps(BlockAndTintGetter world, BlockPos pos, Direction side);
     
     ILogicCache cached();
     

--- a/src/main/java/team/chisel/ctm/client/newctm/ILogicCache.java
+++ b/src/main/java/team/chisel/ctm/client/newctm/ILogicCache.java
@@ -2,7 +2,7 @@ package team.chisel.ctm.client.newctm;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.BlockAndTintGetter;
 import team.chisel.ctm.client.newctm.CTMLogicBakery.OutputFace;
 
 public interface ILogicCache {
@@ -14,5 +14,5 @@ public interface ILogicCache {
     /**
      * Builds the connection map and stores it in this CTM instance.
      */
-    void buildConnectionMap(BlockGetter world, BlockPos pos, Direction side);
+    void buildConnectionMap(BlockAndTintGetter world, BlockPos pos, Direction side);
 }

--- a/src/main/java/team/chisel/ctm/client/newctm/LocalDirection.java
+++ b/src/main/java/team/chisel/ctm/client/newctm/LocalDirection.java
@@ -2,7 +2,7 @@ package team.chisel.ctm.client.newctm;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 
 public interface LocalDirection {
@@ -20,7 +20,7 @@ public interface LocalDirection {
      *            The side of the current face.
      * @return True if the block is connected in the given Dir, false otherwise.
      */
-    boolean isConnected(ConnectionCheck ctm, BlockGetter world, BlockPos pos, Direction side);
+    boolean isConnected(ConnectionCheck ctm, BlockAndTintGetter world, BlockPos pos, Direction side);
 
     /**
      * Finds if this block is connected for the given side in this Dir.
@@ -37,7 +37,7 @@ public interface LocalDirection {
      *            The state to check for connection with.
      * @return True if the block is connected in the given Dir, false otherwise.
      */
-    boolean isConnected(ConnectionCheck ctm, BlockGetter world, BlockPos pos, Direction side, BlockState state);
+    boolean isConnected(ConnectionCheck ctm, BlockAndTintGetter world, BlockPos pos, Direction side, BlockState state);
 
     LocalDirection relativize(Direction normal);
 

--- a/src/main/java/team/chisel/ctm/client/newctm/TextureContextCustomCTM.java
+++ b/src/main/java/team/chisel/ctm/client/newctm/TextureContextCustomCTM.java
@@ -6,7 +6,7 @@ import javax.annotation.Nonnull;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import team.chisel.ctm.api.texture.ICTMTexture;
 import team.chisel.ctm.api.texture.ITextureContext;
@@ -20,7 +20,7 @@ public class TextureContextCustomCTM implements ITextureContext {
 
     private long data;
 
-    public TextureContextCustomCTM(@Nonnull BlockState state, BlockGetter world, BlockPos pos, ICTMTexture<?> tex, ICTMLogic logic) {
+    public TextureContextCustomCTM(@Nonnull BlockState state, BlockAndTintGetter world, BlockPos pos, ICTMTexture<?> tex, ICTMLogic logic) {
     	this.tex = tex;
     	this.logic = logic;
     	

--- a/src/main/java/team/chisel/ctm/client/newctm/TextureTypeCustom.java
+++ b/src/main/java/team/chisel/ctm/client/newctm/TextureTypeCustom.java
@@ -3,13 +3,12 @@ package team.chisel.ctm.client.newctm;
 import java.util.List;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import team.chisel.ctm.api.texture.ICTMTexture;
 import team.chisel.ctm.api.texture.ISubmap;
 import team.chisel.ctm.api.texture.ITextureContext;
 import team.chisel.ctm.api.texture.ITextureType;
-import team.chisel.ctm.api.texture.TextureType;
 import team.chisel.ctm.api.util.TextureInfo;
 
 public class TextureTypeCustom implements ITextureType {
@@ -21,7 +20,7 @@ public class TextureTypeCustom implements ITextureType {
     }
 
     @Override
-    public ITextureContext getBlockRenderContext(BlockState state, BlockGetter world, BlockPos pos, ICTMTexture<?> tex) {
+    public ITextureContext getBlockRenderContext(BlockState state, BlockAndTintGetter world, BlockPos pos, ICTMTexture<?> tex) {
         return new TextureContextCustomCTM(state, world, pos, tex, logic);
     }
 

--- a/src/main/java/team/chisel/ctm/client/state/CTMContext.java
+++ b/src/main/java/team/chisel/ctm/client/state/CTMContext.java
@@ -5,7 +5,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 import lombok.Getter;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import team.chisel.ctm.api.util.RenderContextList;
 import team.chisel.ctm.client.model.AbstractCTMBakedModel;
@@ -14,13 +14,13 @@ import team.chisel.ctm.client.model.AbstractCTMBakedModel;
 public class CTMContext  {
     
     @Getter
-    private final BlockGetter world;
+    private final BlockAndTintGetter world;
     @Getter
     private final BlockPos pos;
     
     private @Nullable RenderContextList ctxCache;
     
-    public CTMContext(BlockGetter world, BlockPos pos) {
+    public CTMContext(BlockAndTintGetter world, BlockPos pos) {
         this.world = world;
         this.pos = pos;
     }

--- a/src/main/java/team/chisel/ctm/client/texture/ctx/TextureContextCTM.java
+++ b/src/main/java/team/chisel/ctm/client/texture/ctx/TextureContextCTM.java
@@ -6,7 +6,7 @@ import javax.annotation.Nonnull;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import team.chisel.ctm.api.texture.ITextureContext;
 import team.chisel.ctm.client.texture.render.TextureCTM;
@@ -20,7 +20,7 @@ public class TextureContextCTM implements ITextureContext {
 
     private long data;
 
-    public TextureContextCTM(@Nonnull BlockState state, BlockGetter world, BlockPos pos, TextureCTM<?> tex) {
+    public TextureContextCTM(@Nonnull BlockState state, BlockAndTintGetter world, BlockPos pos, TextureCTM<?> tex) {
     	this.tex = tex;
     	
         for (Direction face : Direction.values()) {

--- a/src/main/java/team/chisel/ctm/client/texture/type/TextureTypeCTM.java
+++ b/src/main/java/team/chisel/ctm/client/texture/type/TextureTypeCTM.java
@@ -1,7 +1,7 @@
 package team.chisel.ctm.client.texture.type;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import team.chisel.ctm.Configurations;
 import team.chisel.ctm.api.texture.ICTMTexture;
@@ -21,7 +21,7 @@ public class TextureTypeCTM implements ITextureType {
     }
 
     @Override
-    public TextureContextCTM getBlockRenderContext(BlockState state, BlockGetter world, BlockPos pos, ICTMTexture<?> tex) {
+    public TextureContextCTM getBlockRenderContext(BlockState state, BlockAndTintGetter world, BlockPos pos, ICTMTexture<?> tex) {
         return new TextureContextCTM(state, world, pos, (TextureCTM<?>) tex);
     }
 

--- a/src/main/java/team/chisel/ctm/client/texture/type/TextureTypeEdges.java
+++ b/src/main/java/team/chisel/ctm/client/texture/type/TextureTypeEdges.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.Setter;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 import team.chisel.ctm.api.texture.ICTMTexture;
@@ -60,7 +60,7 @@ public class TextureTypeEdges extends TextureTypeCTM {
         private boolean obscured;
         
         @Override
-        public boolean isConnected(BlockGetter world, BlockPos current, BlockPos connection, Direction dir, BlockState state) {
+        public boolean isConnected(BlockAndTintGetter world, BlockPos current, BlockPos connection, Direction dir, BlockState state) {
             if (isObscured()) {
                 return false;
             }
@@ -102,7 +102,7 @@ public class TextureTypeEdges extends TextureTypeCTM {
     }
     
     @Override
-    public TextureContextCTM getBlockRenderContext(BlockState state, BlockGetter world, BlockPos pos, ICTMTexture<?> tex) {
+    public TextureContextCTM getBlockRenderContext(BlockState state, BlockAndTintGetter world, BlockPos pos, ICTMTexture<?> tex) {
         return new TextureContextCTM(state, world, pos, (TextureEdges) tex) {
             
             @Override

--- a/src/main/java/team/chisel/ctm/client/texture/type/TextureTypeEldritch.java
+++ b/src/main/java/team/chisel/ctm/client/texture/type/TextureTypeEldritch.java
@@ -3,7 +3,7 @@ package team.chisel.ctm.client.texture.type;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import team.chisel.ctm.api.texture.ICTMTexture;
 import team.chisel.ctm.api.texture.ITextureContext;
@@ -38,7 +38,7 @@ public class TextureTypeEldritch implements ITextureType {
     }
 
     @Override
-    public ITextureContext getBlockRenderContext(BlockState state, BlockGetter world, BlockPos pos, ICTMTexture<?> tex) {
+    public ITextureContext getBlockRenderContext(BlockState state, BlockAndTintGetter world, BlockPos pos, ICTMTexture<?> tex) {
         return new Context(pos);
     }
 

--- a/src/main/java/team/chisel/ctm/client/texture/type/TextureTypeMap.java
+++ b/src/main/java/team/chisel/ctm/client/texture/type/TextureTypeMap.java
@@ -4,7 +4,7 @@ import javax.annotation.Nonnull;
 
 import lombok.RequiredArgsConstructor;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import team.chisel.ctm.api.texture.ICTMTexture;
 import team.chisel.ctm.api.texture.ITextureContext;
@@ -27,7 +27,7 @@ public class TextureTypeMap implements ITextureType {
     }
     
     @Override
-    public ITextureContext getBlockRenderContext(BlockState state, BlockGetter world, @Nonnull BlockPos pos, ICTMTexture<?> tex) {
+    public ITextureContext getBlockRenderContext(BlockState state, BlockAndTintGetter world, @Nonnull BlockPos pos, ICTMTexture<?> tex) {
         return type.getContext(pos, (TextureMap) tex);
     }
     

--- a/src/main/java/team/chisel/ctm/client/texture/type/TextureTypeNormal.java
+++ b/src/main/java/team/chisel/ctm/client/texture/type/TextureTypeNormal.java
@@ -3,7 +3,7 @@ package team.chisel.ctm.client.texture.type;
 import javax.annotation.Nonnull;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import team.chisel.ctm.api.texture.ICTMTexture;
 import team.chisel.ctm.api.texture.ITextureContext;
@@ -29,7 +29,7 @@ public enum TextureTypeNormal implements ITextureType {
     }
 
     @Override
-    public ITextureContext getBlockRenderContext(BlockState state, BlockGetter world, BlockPos pos, ICTMTexture<?> tex){
+    public ITextureContext getBlockRenderContext(BlockState state, BlockAndTintGetter world, BlockPos pos, ICTMTexture<?> tex){
         return EMPTY_CONTEXT;
     }
 

--- a/src/main/java/team/chisel/ctm/client/texture/type/TextureTypePillar.java
+++ b/src/main/java/team/chisel/ctm/client/texture/type/TextureTypePillar.java
@@ -1,7 +1,7 @@
 package team.chisel.ctm.client.texture.type;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import team.chisel.ctm.api.texture.ICTMTexture;
 import team.chisel.ctm.api.texture.ITextureContext;
@@ -21,7 +21,7 @@ public class TextureTypePillar implements ITextureType {
     }
     
     @Override
-    public TextureContextPillar getBlockRenderContext(BlockState state, BlockGetter world, BlockPos pos, ICTMTexture<?> tex) {
+    public TextureContextPillar getBlockRenderContext(BlockState state, BlockAndTintGetter world, BlockPos pos, ICTMTexture<?> tex) {
         return new TextureContextPillar(world, pos);
     }
     

--- a/src/main/java/team/chisel/ctm/client/texture/type/TextureTypeSCTM.java
+++ b/src/main/java/team/chisel/ctm/client/texture/type/TextureTypeSCTM.java
@@ -1,7 +1,7 @@
 package team.chisel.ctm.client.texture.type;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import team.chisel.ctm.api.texture.ICTMTexture;
 import team.chisel.ctm.api.texture.TextureType;
@@ -23,7 +23,7 @@ public class TextureTypeSCTM extends TextureTypeCTM {
     }
     
     @Override
-    public TextureContextCTM getBlockRenderContext(final BlockState state, final BlockGetter world, final BlockPos pos, final ICTMTexture<?> tex) {
+    public TextureContextCTM getBlockRenderContext(final BlockState state, final BlockAndTintGetter world, final BlockPos pos, final ICTMTexture<?> tex) {
         return new TextureContextCTM(state, world, pos, (TextureCTM<?>) tex) {
         
             @Override

--- a/src/main/java/team/chisel/ctm/client/util/CTMLogic.java
+++ b/src/main/java/team/chisel/ctm/client/util/CTMLogic.java
@@ -18,7 +18,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import lombok.experimental.Accessors;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import team.chisel.ctm.api.texture.ISubmap;
 import team.chisel.ctm.client.newctm.CTMLogicBakery.OutputFace;
@@ -149,7 +149,7 @@ public class CTMLogic implements ICTMLogic, ILogicCache {
 	 *         Indeces are in counter-clockwise order starting at bottom left.
 	 */
 	@Override
-    public int[] getSubmapIds(@Nullable BlockGetter world, BlockPos pos, Direction side) {
+    public int[] getSubmapIds(@Nullable BlockAndTintGetter world, BlockPos pos, Direction side) {
 		if (world == null) {
             return submapCache;
         }
@@ -206,7 +206,7 @@ public class CTMLogic implements ICTMLogic, ILogicCache {
      * Builds the connection map and stores it in this CTM instance. The {@link #connected(Dir)}, {@link #connectedAnd(Dir...)}, and {@link #connectedOr(Dir...)} methods can be used to access it.
      */
     @Override
-    public void buildConnectionMap(BlockGetter world, BlockPos pos, Direction side) {
+    public void buildConnectionMap(BlockAndTintGetter world, BlockPos pos, Direction side) {
         BlockState state = connectionCheck.getConnectionState(world, pos, side, pos);
         // TODO this naive check doesn't work for models that have unculled faces.
         // Perhaps a smarter optimization could be done eventually?
@@ -316,7 +316,7 @@ public class CTMLogic implements ICTMLogic, ILogicCache {
 
     @Override
     @Deprecated
-    public OutputFace[] getSubmaps(BlockGetter world, BlockPos pos, Direction side) {
+    public OutputFace[] getSubmaps(BlockAndTintGetter world, BlockPos pos, Direction side) {
         return new OutputFace[0];
     }
     

--- a/src/main/java/team/chisel/ctm/client/util/CTMLogic.java
+++ b/src/main/java/team/chisel/ctm/client/util/CTMLogic.java
@@ -207,12 +207,15 @@ public class CTMLogic implements ICTMLogic, ILogicCache {
      */
     @Override
     public void buildConnectionMap(BlockAndTintGetter world, BlockPos pos, Direction side) {
-        BlockState state = connectionCheck.getConnectionState(world, pos, side, pos);
+        //BlockState state = connectionCheck.getConnectionState(world, pos, side, pos);
         // TODO this naive check doesn't work for models that have unculled faces.
         // Perhaps a smarter optimization could be done eventually?
 //        if (state.shouldSideBeRendered(world, pos, side)) {
             for (Dir dir : Dir.VALUES) {
-                setConnectedState(dir, dir.isConnected(connectionCheck, world, pos, side, state));
+                //Note: We can't cache the state that we are checking about connection for as we want to ensure that
+                // we can take into account the side of the block we want to know the "state" of as if the block is
+                // a facade of some sort it might return different results based on where it is being queried from
+                setConnectedState(dir, dir.isConnected(connectionCheck, world, pos, side));
             }
 //        }
     }

--- a/src/main/java/team/chisel/ctm/client/util/Dir.java
+++ b/src/main/java/team/chisel/ctm/client/util/Dir.java
@@ -20,7 +20,7 @@ import com.google.gson.Gson;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.util.StringRepresentable;
-import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import team.chisel.ctm.api.util.NonnullType;
 import team.chisel.ctm.client.newctm.ConnectionCheck;
@@ -124,7 +124,7 @@ public enum Dir implements LocalDirection, StringRepresentable {
      * @return True if the block is connected in the given Dir, false otherwise.
      */
     @Override
-    public boolean isConnected(ConnectionCheck ctm, BlockGetter world, BlockPos pos, Direction side) {
+    public boolean isConnected(ConnectionCheck ctm, BlockAndTintGetter world, BlockPos pos, Direction side) {
         return ctm.isConnected(world, pos, applyConnection(pos, side), side);
     }
 
@@ -144,7 +144,7 @@ public enum Dir implements LocalDirection, StringRepresentable {
      * @return True if the block is connected in the given Dir, false otherwise.
      */
     @Override
-    public boolean isConnected(ConnectionCheck ctm, BlockGetter world, BlockPos pos, Direction side, BlockState state) {
+    public boolean isConnected(ConnectionCheck ctm, BlockAndTintGetter world, BlockPos pos, Direction side, BlockState state) {
         return ctm.isConnected(world, pos, applyConnection(pos, side), side, state);
     }
 

--- a/src/test/java/team/chisel/ctm/tests/TestBlockGetter.java
+++ b/src/test/java/team/chisel/ctm/tests/TestBlockGetter.java
@@ -6,16 +6,38 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.ColorResolver;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.LightChunk;
+import net.minecraft.world.level.chunk.LightChunkGetter;
+import net.minecraft.world.level.lighting.LevelLightEngine;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
 
-public class TestBlockGetter implements BlockGetter {
+public class TestBlockGetter implements BlockAndTintGetter {
     
     private final Map<BlockPos, BlockState> blocks = new HashMap<>();
+    private final LevelLightEngine lightEngine;
+
+    public TestBlockGetter() {
+        this.lightEngine = new LevelLightEngine(new LightChunkGetter() {
+            @Nullable
+            @Override
+            public LightChunk getChunkForLighting(int chunkX, int chunkZ) {
+                return null;
+            }
+
+            @Override
+            public BlockGetter getLevel() {
+                return TestBlockGetter.this;
+            }
+        }, false, false);
+    }
     
     void addBlock(BlockPos pos, BlockState state) {
         blocks.put(pos, state);
@@ -51,4 +73,18 @@ public class TestBlockGetter implements BlockGetter {
         return Fluids.EMPTY.defaultFluidState(); 
     }
 
+    @Override
+    public float getShade(Direction direction, boolean shade) {
+        return 0;
+    }
+
+    @Override
+    public LevelLightEngine getLightEngine() {
+        return lightEngine;
+    }
+
+    @Override
+    public int getBlockTint(BlockPos pos, ColorResolver colorResolver) {
+        return 0;
+    }
 }


### PR DESCRIPTION
This PR makes a couple minor breaking changes to some method signatures in the API to switch them from `BlockGetter` to `BlockAndTintGetter`. Theoretically we could do this in a non-breaking way but as it would be a bit of a mess and there hasn't been a 1.20 release of CTM yet, it doesn't seem worth the effort.

This PR also deprecates `IFacade` in favor of mods implementing `IForgeBlock#getAppearance` (#173) as that way they can support other mods that may add CTM like features, and also doesn't require them to have a hard dependency on CTM.

Preview of a combination of steel casing (block from mekanism), framed blocks (with the appearance of steel casing), and AE2 cable facades (with the appearance of steel casing)
![image](https://github.com/Chisel-Team/ConnectedTexturesMod/assets/1203288/926151dd-2d38-4a6e-bfd1-bb0e25762a00)
