### PR TITLE
Improve functionality and fix some bugs for the newer Custom CTM format

### DIFF
--- a/src/main/java/team/chisel/ctm/client/newctm/CTMLogicBakery.java
+++ b/src/main/java/team/chisel/ctm/client/newctm/CTMLogicBakery.java
@@ -3,6 +3,7 @@ package team.chisel.ctm.client.newctm;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.function.IntFunction;
@@ -183,12 +184,12 @@ public class CTMLogicBakery {
                 }
             }
         }
-        return new CustomCTMLogic(lookups, asSortedArray(outputs, OutputFace[]::new), asSortedArray(bitmap, LocalDirection[]::new), new ConnectionCheck());
+        return new CustomCTMLogic(lookups, asSortedArray(outputs, OutputFace[]::new), asSortedArray(bitmap, LocalDirection[]::new));
     }
     
     private <T> T[] asSortedArray(Int2ObjectMap<T> indexedMap, IntFunction<T[]> ctor) {
         return indexedMap.int2ObjectEntrySet().stream()
-            .sorted((e1, e2) -> Integer.compare(e1.getIntKey(), e2.getIntKey()))
+            .sorted(Comparator.comparingInt(Int2ObjectMap.Entry::getIntKey))
             .map(Entry::getValue)
             .toArray(ctor);
     }

--- a/src/main/java/team/chisel/ctm/client/newctm/CustomCTMLogic.java
+++ b/src/main/java/team/chisel/ctm/client/newctm/CustomCTMLogic.java
@@ -7,6 +7,7 @@ import java.util.Set;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import javax.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -21,13 +22,19 @@ public class CustomCTMLogic implements ICTMLogic {
     public final int[][] lookups;
     private final OutputFace[] tiles;
     private final LocalDirection[] directions;
-    private final ConnectionCheck connectionCheck;
+    private ConnectionCheck connectionCheck = new ConnectionCheck();
     
     private class Cache implements ILogicCache {
-        
+
+        @Nullable
+        private final ConnectionCheck connectionCheckOverride;
         private int[] cachedSubmapIds;
         private OutputFace[] cachedSubmaps;
-        
+
+        public Cache(@Nullable ConnectionCheck connectionCheck) {
+            this.connectionCheckOverride = connectionCheck;
+        }
+
         @Override
         public OutputFace[] getCachedSubmaps() {
             return this.cachedSubmaps;
@@ -49,8 +56,13 @@ public class CustomCTMLogic implements ICTMLogic {
 
         @Override
         public void buildConnectionMap(BlockAndTintGetter world, BlockPos pos, Direction side) {
+            ConnectionCheck oldConnectionCheck = connectionCheck;
+            if (connectionCheckOverride != null) {
+                connectionCheck = connectionCheckOverride;
+            }
             this.cachedSubmapIds = CustomCTMLogic.this.getSubmapIds(world, pos, side);
             this.cachedSubmaps = CustomCTMLogic.this.getSubmaps(world, pos, side);
+            connectionCheck = oldConnectionCheck;
         }
     }
 
@@ -64,8 +76,7 @@ public class CustomCTMLogic implements ICTMLogic {
         if (key >= lookups.length || lookups[key] == null) {
             throw new IllegalStateException("Input state found that is not in lookup table: " + Integer.toBinaryString(key));
         }
-        int[] tileIds = lookups[key];
-        return tileIds;
+        return lookups[key];
     }
 
     @Override
@@ -79,8 +90,8 @@ public class CustomCTMLogic implements ICTMLogic {
     }
     
     @Override
-    public ILogicCache cached() {
-        return this.new Cache();
+    public ILogicCache cached(@Nullable ConnectionCheck connectionCheck) {
+        return this.new Cache(connectionCheck);
     }
     
     private List<ISubmap> outputSubmapCache;
@@ -95,7 +106,12 @@ public class CustomCTMLogic implements ICTMLogic {
         }
         return outputSubmapCache;
     }
-    
+
+    @Override
+    public ISubmap getFallbackUvs() {
+        return tiles.length == 0 ? ICTMLogic.super.getFallbackUvs() : tiles[0].getUvs();
+    }
+
     private int textureCountCache = -1;
     @Override
     public int requiredTextures() {

--- a/src/main/java/team/chisel/ctm/client/newctm/ICTMLogic.java
+++ b/src/main/java/team/chisel/ctm/client/newctm/ICTMLogic.java
@@ -2,11 +2,13 @@ package team.chisel.ctm.client.newctm;
 
 import java.util.List;
 
+import javax.annotation.Nullable;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.BlockAndTintGetter;
 import team.chisel.ctm.api.texture.ISubmap;
 import team.chisel.ctm.client.newctm.CTMLogicBakery.OutputFace;
+import team.chisel.ctm.client.util.Submap;
 
 public interface ICTMLogic {
     
@@ -14,9 +16,13 @@ public interface ICTMLogic {
     
     OutputFace[] getSubmaps(BlockAndTintGetter world, BlockPos pos, Direction side);
     
-    ILogicCache cached();
+    ILogicCache cached(@Nullable ConnectionCheck connectionCheck);
     
     List<ISubmap> outputSubmaps();
+
+    default ISubmap getFallbackUvs() {
+        return Submap.X1;
+    }
     
     int requiredTextures();
 

--- a/src/main/java/team/chisel/ctm/client/newctm/ITextureConnection.java
+++ b/src/main/java/team/chisel/ctm/client/newctm/ITextureConnection.java
@@ -1,0 +1,21 @@
+package team.chisel.ctm.client.newctm;
+
+import java.util.Optional;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.state.BlockState;
+
+public interface ITextureConnection {
+
+    boolean ignoreStates();
+
+    boolean connectTo(ConnectionCheck ctm, BlockState from, BlockState to, Direction dir);
+
+    Optional<Boolean> connectInside();
+
+    default ConnectionCheck applyTo(ConnectionCheck check) {
+        check.ignoreStates(ignoreStates())
+              .stateComparator(this::connectTo);
+        check.disableObscuredFaceCheck = connectInside();
+        return check;
+    }
+}

--- a/src/main/java/team/chisel/ctm/client/newctm/TextureContextCustomCTM.java
+++ b/src/main/java/team/chisel/ctm/client/newctm/TextureContextCustomCTM.java
@@ -11,7 +11,6 @@ import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import team.chisel.ctm.api.texture.ICTMTexture;
 import team.chisel.ctm.api.texture.ITextureContext;
-import team.chisel.ctm.client.texture.render.TextureCTM;
 
 public class TextureContextCustomCTM implements ITextureContext {
     
@@ -26,16 +25,8 @@ public class TextureContextCustomCTM implements ITextureContext {
     	this.tex = tex;
     	this.logic = logic;
         ConnectionCheck connectionCheckOverride = null;
-        if (this.tex instanceof TextureCustomCTM<?> texCtm) {
-            connectionCheckOverride = new ConnectionCheck()
-                  .ignoreStates(texCtm.ignoreStates())
-                  .stateComparator(texCtm::connectTo);
-            connectionCheckOverride.disableObscuredFaceCheck = texCtm.connectInside();
-        } else if (this.tex instanceof TextureCTM<?> texCtm) {
-            connectionCheckOverride = new ConnectionCheck()
-                  .ignoreStates(texCtm.ignoreStates())
-                  .stateComparator(texCtm::connectTo);
-            connectionCheckOverride.disableObscuredFaceCheck = texCtm.connectInside();
+        if (this.tex instanceof ITextureConnection texCtm) {
+            connectionCheckOverride = texCtm.applyTo(new ConnectionCheck());
         }
     	
         for (Direction face : Direction.values()) {

--- a/src/main/java/team/chisel/ctm/client/newctm/TextureContextCustomCTM.java
+++ b/src/main/java/team/chisel/ctm/client/newctm/TextureContextCustomCTM.java
@@ -4,12 +4,14 @@ import java.util.EnumMap;
 
 import javax.annotation.Nonnull;
 
+import javax.annotation.Nullable;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import team.chisel.ctm.api.texture.ICTMTexture;
 import team.chisel.ctm.api.texture.ITextureContext;
+import team.chisel.ctm.client.texture.render.TextureCTM;
 
 public class TextureContextCustomCTM implements ITextureContext {
     
@@ -23,17 +25,29 @@ public class TextureContextCustomCTM implements ITextureContext {
     public TextureContextCustomCTM(@Nonnull BlockState state, BlockAndTintGetter world, BlockPos pos, ICTMTexture<?> tex, ICTMLogic logic) {
     	this.tex = tex;
     	this.logic = logic;
+        ConnectionCheck connectionCheckOverride = null;
+        if (this.tex instanceof TextureCustomCTM<?> texCtm) {
+            connectionCheckOverride = new ConnectionCheck()
+                  .ignoreStates(texCtm.ignoreStates())
+                  .stateComparator(texCtm::connectTo);
+            connectionCheckOverride.disableObscuredFaceCheck = texCtm.connectInside();
+        } else if (this.tex instanceof TextureCTM<?> texCtm) {
+            connectionCheckOverride = new ConnectionCheck()
+                  .ignoreStates(texCtm.ignoreStates())
+                  .stateComparator(texCtm::connectTo);
+            connectionCheckOverride.disableObscuredFaceCheck = texCtm.connectInside();
+        }
     	
         for (Direction face : Direction.values()) {
-            ILogicCache ctm = createCTM(state);
+            ILogicCache ctm = createCTM(state, connectionCheckOverride);
             ctm.buildConnectionMap(world, pos, face);
             ctmData.put(face, ctm);
             this.data |= ctm.serialized() << (face.ordinal() * 10);
         }
     }
     
-    protected ILogicCache createCTM(@Nonnull BlockState state) {
-        return logic.cached();
+    protected ILogicCache createCTM(@Nonnull BlockState state, @Nullable ConnectionCheck connectionCheckOverride) {
+        return logic.cached(connectionCheckOverride);
     }
 
     public ILogicCache getCTM(Direction face) {

--- a/src/main/java/team/chisel/ctm/client/newctm/TextureCustomCTM.java
+++ b/src/main/java/team/chisel/ctm/client/newctm/TextureCustomCTM.java
@@ -30,7 +30,7 @@ import team.chisel.ctm.client.util.Quad;
 
 @ParametersAreNonnullByDefault
 @Accessors(fluent = true)
-public class TextureCustomCTM<T extends TextureTypeCustom> extends AbstractTexture<T> {
+public class TextureCustomCTM<T extends TextureTypeCustom> extends AbstractTexture<T> implements ITextureConnection {
 
     private static final BlockstatePredicateParser predicateParser = new BlockstatePredicateParser();
 
@@ -85,6 +85,7 @@ public class TextureCustomCTM<T extends TextureTypeCustom> extends AbstractTextu
         this.particleSprite = PartialTextureAtlasSprite.createPartial(super.getParticle(), type.getFallbackUvs());
     }
 
+    @Override
     public boolean connectTo(ConnectionCheck ctm, BlockState from, BlockState to, Direction dir) {
         try {
             return ((connectionChecks == null ? StateComparisonCallback.DEFAULT.connects(ctm, from, to, dir) : connectionChecks.test(dir, to)) ? 1 : 0) == 1;

--- a/src/main/java/team/chisel/ctm/client/newctm/TextureTypeCustom.java
+++ b/src/main/java/team/chisel/ctm/client/newctm/TextureTypeCustom.java
@@ -44,4 +44,8 @@ public class TextureTypeCustom implements ITextureType {
     public TextureCustomCTM<? extends TextureTypeCustom> makeTexture(TextureInfo info) {
         return new TextureCustomCTM<>(this, info);
     }
+
+    public ISubmap getFallbackUvs() {
+        return logic.getFallbackUvs();
+    }
 }

--- a/src/main/java/team/chisel/ctm/client/texture/ctx/TextureContextCTM.java
+++ b/src/main/java/team/chisel/ctm/client/texture/ctx/TextureContextCTM.java
@@ -33,10 +33,7 @@ public class TextureContextCTM implements ITextureContext {
     
     protected CTMLogic createCTM(@Nonnull BlockState state) {
         CTMLogic ret = CTMLogic.getInstance();
-        ret.connectionCheck
-                .ignoreStates(tex.ignoreStates())
-                .stateComparator(tex::connectTo);
-        ret.connectionCheck.disableObscuredFaceCheck = tex.connectInside();
+        tex.applyTo(ret.connectionCheck);
         return ret;
     }
 

--- a/src/main/java/team/chisel/ctm/client/texture/render/TextureCTM.java
+++ b/src/main/java/team/chisel/ctm/client/texture/render/TextureCTM.java
@@ -25,6 +25,7 @@ import team.chisel.ctm.Configurations;
 import team.chisel.ctm.api.texture.ITextureContext;
 import team.chisel.ctm.api.util.TextureInfo;
 import team.chisel.ctm.client.newctm.ConnectionCheck;
+import team.chisel.ctm.client.newctm.ITextureConnection;
 import team.chisel.ctm.client.texture.ctx.TextureContextCTM;
 import team.chisel.ctm.client.texture.type.TextureTypeCTM;
 import team.chisel.ctm.client.util.BlockstatePredicateParser;
@@ -35,7 +36,7 @@ import team.chisel.ctm.client.util.Quad;
 
 @ParametersAreNonnullByDefault
 @Accessors(fluent = true)
-public class TextureCTM<T extends TextureTypeCTM> extends AbstractTexture<T> {
+public class TextureCTM<T extends TextureTypeCTM> extends AbstractTexture<T> implements ITextureConnection {
 
     private static final BlockstatePredicateParser predicateParser = new BlockstatePredicateParser();
 
@@ -88,6 +89,7 @@ public class TextureCTM<T extends TextureTypeCTM> extends AbstractTexture<T> {
         this.connectionChecks = info.getInfo().map(obj -> predicateParser.parse(obj.get("connect_to"))).orElse(null);
     }
 
+    @Override
     public boolean connectTo(ConnectionCheck ctm, BlockState from, BlockState to, Direction dir) {
         try {
             return ((connectionChecks == null ? StateComparisonCallback.DEFAULT.connects(ctm, from, to, dir) : connectionChecks.test(dir, to)) ? 1 : 0) == 1;

--- a/src/main/java/team/chisel/ctm/client/util/CTMLogic.java
+++ b/src/main/java/team/chisel/ctm/client/util/CTMLogic.java
@@ -325,7 +325,7 @@ public class CTMLogic implements ICTMLogic, ILogicCache {
     
     @Override
     @Deprecated
-    public ILogicCache cached() {
+    public ILogicCache cached(@Nullable ConnectionCheck connectionCheck) {
         return this;
     }
     

--- a/src/main/java/team/chisel/ctm/client/util/PartialTextureAtlasSprite.java
+++ b/src/main/java/team/chisel/ctm/client/util/PartialTextureAtlasSprite.java
@@ -1,0 +1,99 @@
+package team.chisel.ctm.client.util;
+
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import team.chisel.ctm.api.texture.ISubmap;
+
+public class PartialTextureAtlasSprite extends TextureAtlasSprite {
+
+    public static TextureAtlasSprite createPartial(TextureAtlasSprite sprite, ISubmap submap) {
+        submap = submap.unitScale();
+        if (submap.getXOffset() == 0 && submap.getYOffset() == 0 && submap.getWidth() == 1 && submap.getHeight() == 1) {
+            return sprite;
+        }
+
+        float width = sprite.getU1() - sprite.getU0();
+        float height = sprite.getV1() - sprite.getV0();
+
+        float atlasWidth = sprite.contents().width() / width;
+        float atlasHeight = sprite.contents().height() / height;
+
+        float uWidth = width * submap.getWidth();
+        float vHeight = height * submap.getHeight();
+        float xOffset = Quad.lerp(sprite.getU0(), sprite.getU1(), submap.getXOffset());
+        float yOffset = Quad.lerp(sprite.getV0(), sprite.getV1(), submap.getYOffset());
+        return new PartialTextureAtlasSprite(sprite, atlasWidth, atlasHeight, xOffset, uWidth, yOffset, vHeight);
+    }
+
+    private final float u0;
+    private final float u1;
+    private final float v0;
+    private final float v1;
+
+    protected PartialTextureAtlasSprite(TextureAtlasSprite sprite, float atlasWidth, float atlasHeight, float xOffset, float uWidth, float yOffset, float vHeight) {
+        super(sprite.atlasLocation(), sprite.contents(), (int) atlasWidth, (int) atlasHeight, sprite.getX(), sprite.getY());
+        this.u0 = xOffset;
+        this.u1 = xOffset + uWidth;
+        this.v0 = yOffset;
+        this.v1 = yOffset + vHeight;
+    }
+
+    @Override
+    public float getU0() {
+        return this.u0;
+    }
+
+    @Override
+    public float getU1() {
+        return this.u1;
+    }
+
+    @Override
+    public float getU(double u) {
+        float width = getU1() - getU0();
+        return getU0() + width * (float) u / 16.0F;
+    }
+
+    @Override
+    public float getUOffset(float offset) {
+        float width = getU1() - getU0();
+        return (offset - getU0()) / width * 16.0F;
+    }
+
+    @Override
+    public float getV0() {
+        return this.v0;
+    }
+
+    @Override
+    public float getV1() {
+        return this.v1;
+    }
+
+    @Override
+    public float getV(double v) {
+        float height = getV1() - getV0();
+        return getV0() + height * (float) v / 16.0F;
+    }
+
+    @Override
+    public float getVOffset(float offset) {
+        float height = getV1() - getV0();
+        return (offset - getV0()) / height * 16.0F;
+    }
+
+    @Override
+    public String toString() {
+        return "PartialTextureAtlasSprite{contents='" + contents() + "', u0=" + getU0() + ", u1=" + getU1() + ", v0=" + getV0() + ", v1=" + getV1() + "}";
+    }
+
+    private float atlasSize() {
+        float atlasWidth = contents().width() / (getU1() - getU0());
+        float atlasHeight = contents().height() / (getV1() - getV0());
+        return Math.max(atlasWidth, atlasHeight);
+    }
+
+    @Override
+    public float uvShrinkRatio() {
+        return 4.0F / atlasSize();
+    }
+}


### PR DESCRIPTION
- Fix custom ctm not mapping textures for items properly
- Fix including drastically too much of the texture for the particle with custom ctm textures
- Make the custom ctm logic support custom connection checks by making the specific new cache instance support overriding the connection check. This allows for support for `connect_to` for custom ctm textures