### PR TITLE
Port to 1.21 and make it so the normal check can't throw a NPE (#219)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,14 @@ tasks.named('jar', Jar).configure { Jar jar ->
 
 repositories {
     mavenLocal()
+    maven {
+        name 'Maven for PR #1076' // https://github.com/neoforged/NeoForge/pull/1076
+        url 'https://prmaven.neoforged.net/NeoForge/pr1076'
+        content {
+            includeModule('net.neoforged', 'testframework')
+            includeModule('net.neoforged', 'neoforge')
+        }
+    }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -74,14 +74,6 @@ tasks.named('jar', Jar).configure { Jar jar ->
 
 repositories {
     mavenLocal()
-    maven {
-        name 'Maven for PR #1076' // https://github.com/neoforged/NeoForge/pull/1076
-        url 'https://prmaven.neoforged.net/NeoForge/pr1076'
-        content {
-            includeModule('net.neoforged', 'testframework')
-            includeModule('net.neoforged', 'neoforge')
-        }
-    }
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 mod_version=1.1.11
-minecraft_version=1.20.6
-forge_version=20.6.113-beta
+minecraft_version=1.21
+forge_version=21.0.0-alpha.1.21-rc1.20240611.222608
 
 curse_type=beta
 projectId=267602

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 mod_version=1.1.11
 minecraft_version=1.21
-forge_version=21.0.0-alpha.1.21-rc1.20240611.222608
+forge_version=21.0.0-beta
 
 curse_type=beta
 projectId=267602

--- a/src/main/java/team/chisel/ctm/CTM.java
+++ b/src/main/java/team/chisel/ctm/CTM.java
@@ -56,7 +56,7 @@ public class CTM {
     }
 
     private void modelRegistry(ModelEvent.RegisterGeometryLoaders event) {
-        event.register(new ResourceLocation(MOD_ID, "ctm"), ModelLoaderCTM.INSTANCE);
+        event.register(ResourceLocation.fromNamespaceAndPath(MOD_ID, "ctm"), ModelLoaderCTM.INSTANCE);
     }
 
     private void imc(InterModEnqueueEvent event) {

--- a/src/main/java/team/chisel/ctm/client/model/AbstractCTMBakedModel.java
+++ b/src/main/java/team/chisel/ctm/client/model/AbstractCTMBakedModel.java
@@ -84,7 +84,7 @@ public abstract class AbstractCTMBakedModel extends BakedModelWrapper<BakedModel
         @SneakyThrows
         public BakedModel resolve(BakedModel originalModel, ItemStack stack, ClientLevel world, LivingEntity entity, int unknown) {
             ModelResourceLocation mrl = ModelUtil.getMesh(stack);
-            if (mrl == ModelBakery.MISSING_MODEL_LOCATION) {
+            if (mrl == ModelBakery.MISSING_MODEL_VARIANT) {
                 // this must be a missing/invalid model
                 return Minecraft.getInstance().getBlockRenderer().getBlockModelShaper().getModelManager().getMissingModel();
             }

--- a/src/main/java/team/chisel/ctm/client/model/ModelCTM.java
+++ b/src/main/java/team/chisel/ctm/client/model/ModelCTM.java
@@ -85,7 +85,7 @@ public class ModelCTM implements IModelCTM {
         for (Int2ObjectMap.Entry<JsonElement> e : this.overrides.int2ObjectEntrySet()) {
             IMetadataSectionCTM meta = null;
             if (e.getValue().isJsonPrimitive() && e.getValue().getAsJsonPrimitive().isString()) {
-                ResourceLocation rl = new ResourceLocation(e.getValue().getAsString());
+                ResourceLocation rl = ResourceLocation.parse(e.getValue().getAsString());
                 meta = ResourceUtil.getMetadata(ResourceUtil.spriteToAbsolute(rl)).orElse(null); // TODO lazy null
                 textureDependencies.add(rl);
             } else if (e.getValue().isJsonObject()) {
@@ -106,20 +106,20 @@ public class ModelCTM implements IModelCTM {
 	}
 	
 	@Override
-    public BakedModel bake(IGeometryBakingContext context, ModelBaker bakery, Function<Material, TextureAtlasSprite> spriteGetter, ModelState modelState, ItemOverrides overrides, ResourceLocation modelLocation) {
-		return bake(bakery, spriteGetter, modelState, modelLocation);
+    public BakedModel bake(IGeometryBakingContext context, ModelBaker bakery, Function<Material, TextureAtlasSprite> spriteGetter, ModelState modelState, ItemOverrides overrides) {
+		return bake(bakery, spriteGetter, modelState);
 	}
 
 	private static final ItemModelGenerator ITEM_MODEL_GENERATOR = new ItemModelGenerator();
 
-	public BakedModel bake(ModelBaker bakery, Function<Material, TextureAtlasSprite> spriteGetter, ModelState modelTransform, ResourceLocation modelLocation) {
+	public BakedModel bake(ModelBaker bakery, Function<Material, TextureAtlasSprite> spriteGetter, ModelState modelTransform) {
         BakedModel parent;
         if (modelinfo != null && modelinfo.getRootModel() == ModelBakery.GENERATION_MARKER) { // Apply same special case that ModelBakery does
-            return ITEM_MODEL_GENERATOR.generateBlockModel(spriteGetter, modelinfo).bake(bakery, modelinfo, spriteGetter, modelTransform, modelLocation, false);
+            return ITEM_MODEL_GENERATOR.generateBlockModel(spriteGetter, modelinfo).bake(bakery, modelinfo, spriteGetter, modelTransform, false);
         } else {
             initializeOverrides(spriteGetter);
             this.textureDependencies.forEach(t -> initializeTexture(new Material(TextureAtlas.LOCATION_BLOCKS, t), spriteGetter));
-            parent = vanillamodel.bake(bakery, mat -> initializeTexture(mat, spriteGetter), modelTransform, modelLocation);
+            parent = vanillamodel.bake(bakery, mat -> initializeTexture(mat, spriteGetter), modelTransform);
             if (!isInitialized()) {
                 this.spriteOverrides = new Int2ObjectOpenHashMap<>();
                 this.textureOverrides = new HashMap<>();
@@ -157,7 +157,7 @@ public class ModelCTM implements IModelCTM {
             // Convert all primitive values into sprites
             for (Int2ObjectMap.Entry<JsonElement> e : overrides.int2ObjectEntrySet()) {
                 if (e.getValue().isJsonPrimitive() && e.getValue().getAsJsonPrimitive().isString()) {
-                    TextureAtlasSprite override = spriteGetter.apply(new Material(TextureAtlas.LOCATION_BLOCKS, new ResourceLocation(e.getValue().getAsString())));
+                    TextureAtlasSprite override = spriteGetter.apply(new Material(TextureAtlas.LOCATION_BLOCKS, ResourceLocation.parse(e.getValue().getAsString())));
                     spriteOverrides.put(e.getIntKey(), override);
                 }
             }
@@ -165,10 +165,10 @@ public class ModelCTM implements IModelCTM {
         if (textureOverrides == null) {
             textureOverrides = new HashMap<>();
             for (Int2ObjectMap.Entry<IMetadataSectionCTM> e : metaOverrides.int2ObjectEntrySet()) {
-                List<BlockElementFace> matches = modelinfo.getElements().stream().flatMap(b -> b.faces.values().stream()).filter(b -> b.tintIndex == e.getIntKey()).toList();
+                List<BlockElementFace> matches = modelinfo.getElements().stream().flatMap(b -> b.faces.values().stream()).filter(b -> b.tintIndex() == e.getIntKey()).toList();
                 Multimap<Material, BlockElementFace> bySprite = HashMultimap.create();
                 // TODO 1.15 this isn't right
-                matches.forEach(part -> bySprite.put(modelinfo.textureMap.getOrDefault(part.texture.substring(1), Either.right(part.texture)).left().get(), part));
+                matches.forEach(part -> bySprite.put(modelinfo.textureMap.getOrDefault(part.texture().substring(1), Either.right(part.texture())).left().get(), part));
                 for (var e2 : bySprite.asMap().entrySet()) {
                     ResourceLocation texLoc = e2.getKey().sprite().contents().name();
                     TextureAtlasSprite override = getOverrideSprite(e.getIntKey());

--- a/src/main/java/team/chisel/ctm/client/model/ModelUtil.java
+++ b/src/main/java/team/chisel/ctm/client/model/ModelUtil.java
@@ -26,7 +26,7 @@ public class ModelUtil {
         if (shaper instanceof RegistryAwareItemModelShaper registryAwareShaper) {
             return registryAwareShaper.getLocation(stack);
         }
-        return ModelBakery.MISSING_MODEL_LOCATION;
+        return ModelBakery.MISSING_MODEL_VARIANT;
     }
 
 }

--- a/src/main/java/team/chisel/ctm/client/texture/IMetadataSectionCTM.java
+++ b/src/main/java/team/chisel/ctm/client/texture/IMetadataSectionCTM.java
@@ -51,7 +51,7 @@ public interface IMetadataSectionCTM {
         IMetadataSectionCTM meta = this;
         boolean hasProxy = getProxy() != null;
         if (hasProxy) {
-            TextureAtlasSprite proxySprite = bakedTextureGetter.apply(new Material(TextureAtlas.LOCATION_BLOCKS, new ResourceLocation(getProxy())));
+            TextureAtlasSprite proxySprite = bakedTextureGetter.apply(new Material(TextureAtlas.LOCATION_BLOCKS, ResourceLocation.parse(getProxy())));
             try {
                 meta = ResourceUtil.getMetadata(proxySprite).orElse(new V1());
                 sprite = proxySprite;
@@ -132,7 +132,7 @@ public interface IMetadataSectionCTM {
                     for (int i = 0; i < texturesArr.size(); i++) {
                         JsonElement e = texturesArr.get(i);
                         if (e.isJsonPrimitive() && e.getAsJsonPrimitive().isString()) {
-                            ret.additionalTextures[i] = new ResourceLocation(e.getAsString());
+                            ret.additionalTextures[i] = ResourceLocation.parse(e.getAsString());
                         }
                     }
                 }

--- a/src/main/java/team/chisel/ctm/client/util/BlockstatePredicateParser.java
+++ b/src/main/java/team/chisel/ctm/client/util/BlockstatePredicateParser.java
@@ -132,7 +132,7 @@ public class BlockstatePredicateParser {
         public Predicate<BlockState> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
             if (json.isJsonObject()) {
                 JsonObject obj = json.getAsJsonObject();
-                Block block = BuiltInRegistries.BLOCK.get(new ResourceLocation(GsonHelper.getAsString(obj, "block")));
+                Block block = BuiltInRegistries.BLOCK.get(ResourceLocation.parse(GsonHelper.getAsString(obj, "block")));
                 if (block == Blocks.AIR) {
                     return EMPTY;
                 }

--- a/src/main/java/team/chisel/ctm/client/util/VertexData.java
+++ b/src/main/java/team/chisel/ctm/client/util/VertexData.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import net.minecraft.world.phys.Vec2;
 import net.minecraft.world.phys.Vec3;
+import org.joml.Vector3f;
 
 @Getter
 @ToString
@@ -18,7 +19,7 @@ import net.minecraft.world.phys.Vec3;
 @AllArgsConstructor
 public class VertexData {
 
-    private double posX, posY, posZ;
+    private float posX, posY, posZ;
     private float normalX, normalY, normalZ;
 
     //Store int representations of the colors so that we don't go between ints and doubles when unpacking and repacking a vertex
@@ -33,8 +34,8 @@ public class VertexData {
 
     private Map<VertexFormatElement, int[]> miscData = new HashMap<>();
 
-    public Vec3 getPos() {
-        return new Vec3(posX, posY, posZ);
+    public Vector3f getPos() {
+        return new Vector3f(posX, posY, posZ);
     }
 
     public Vec2 getUV() {
@@ -57,7 +58,7 @@ public class VertexData {
         return this;
     }
 
-    public VertexData pos(double x, double y, double z) {
+    public VertexData pos(float x, float y, float z) {
         this.posX = x;
         this.posY = y;
         this.posZ = z;
@@ -113,15 +114,14 @@ public class VertexData {
     }
 
     public void write(VertexConsumer consumer) {
-        consumer.vertex(posX, posY, posZ);
-        consumer.color(red, green, blue, alpha);
-        consumer.uv(texU, texV);
-        consumer.overlayCoords(overlayU, overlayV);
-        consumer.uv2(lightU, lightV);
-        consumer.normal(normalX, normalY, normalZ);
+        consumer.addVertex(posX, posY, posZ);
+        consumer.setColor(red, green, blue, alpha);
+        consumer.setUv(texU, texV);
+        consumer.setUv1(overlayU, overlayV);
+        consumer.setUv2(lightU, lightV);
+        consumer.setNormal(normalX, normalY, normalZ);
         for (Map.Entry<VertexFormatElement, int[]> entry : miscData.entrySet()) {
             consumer.misc(entry.getKey(), entry.getValue());
         }
-        consumer.endVertex();
     }
 }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -3,6 +3,7 @@ public net.minecraft.client.resources.model.WeightedBakedModel totalWeight
 public net.minecraft.client.resources.model.WeightedBakedModel list
 
 # ModelBakery hacks
+public net.minecraft.client.resources.model.ModelBakery topLevelModels
+public net.minecraft.client.resources.model.ModelBakery getModel(Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/client/resources/model/UnbakedModel;
 public net.minecraft.client.resources.model.ModelBakery$ModelBakerImpl
 public net.minecraft.client.resources.model.ModelBakery$ModelBakerImpl <init>(Lnet/minecraft/client/resources/model/ModelBakery;Lnet/minecraft/client/resources/model/ModelBakery$TextureGetter;Lnet/minecraft/client/resources/model/ModelResourceLocation;)V
-public net.minecraft.client.resources.model.ModelBakery getModel(Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/client/resources/model/UnbakedModel;

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -4,4 +4,5 @@ public net.minecraft.client.resources.model.WeightedBakedModel list
 
 # ModelBakery hacks
 public net.minecraft.client.resources.model.ModelBakery$ModelBakerImpl
-public net.minecraft.client.resources.model.ModelBakery$ModelBakerImpl <init>(Lnet/minecraft/client/resources/model/ModelBakery;Ljava/util/function/BiFunction;Lnet/minecraft/resources/ResourceLocation;)V
+public net.minecraft.client.resources.model.ModelBakery$ModelBakerImpl <init>(Lnet/minecraft/client/resources/model/ModelBakery;Lnet/minecraft/client/resources/model/ModelBakery$TextureGetter;Lnet/minecraft/client/resources/model/ModelResourceLocation;)V
+public net.minecraft.client.resources.model.ModelBakery getModel(Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/client/resources/model/UnbakedModel;

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml"
-loaderVersion="[3,)"
+loaderVersion="[4,)"
 issueTrackerURL="https://github.com/Chisel-Team/ConnectedTexturesMod/issues/"
 license="GPL-2.0"
 
@@ -20,6 +20,6 @@ license="GPL-2.0"
 [[dependencies.ctm]]
     modId="neoforge"
     type="required"
-    versionRange="[20.6.77-beta,)"
+    versionRange="[21.0.0-beta,)"
     ordering="NONE"
     side="BOTH"

--- a/src/main/resources/ctm.mixins.json
+++ b/src/main/resources/ctm.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "team.chisel.ctm.client.mixin",
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_21",
   "mixins": [
     "TextureScrapingMixin"
   ],

--- a/src/test/java/team/chisel/ctm/tests/NewCTMLogicTest.java
+++ b/src/test/java/team/chisel/ctm/tests/NewCTMLogicTest.java
@@ -10,7 +10,6 @@ import java.io.InputStreamReader;
 import java.util.Arrays;
 
 import net.neoforged.neoforge.client.model.pipeline.QuadBakingVertexConsumer;
-import net.neoforged.neoforge.client.model.pipeline.QuadBakingVertexConsumer.Buffered;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -38,13 +37,13 @@ public class NewCTMLogicTest {
     
     @Test
     void quad() {
-        QuadBakingVertexConsumer.Buffered builder = new Buffered();
-        builder.vertex(0, 0, 0).uv(0, 0).normal(0, 1, 0).endVertex();
-        builder.vertex(1, 0, 0).uv(1, 0).normal(0, 1, 0).endVertex();
-        builder.vertex(1, 0, 1).uv(1, 1).normal(0, 1, 0).endVertex();
-        builder.vertex(0, 0, 1).uv(0, 1).normal(0, 1, 0).endVertex();
+        QuadBakingVertexConsumer builder = new QuadBakingVertexConsumer();
+        builder.addVertex(0, 0, 0).setUv(0, 0).setNormal(0, 1, 0);
+        builder.addVertex(1, 0, 0).setUv(1, 0).setNormal(0, 1, 0);
+        builder.addVertex(1, 0, 1).setUv(1, 1).setNormal(0, 1, 0);
+        builder.addVertex(0, 0, 1).setUv(0, 1).setNormal(0, 1, 0);
         
-        Quad q = Quad.from(builder.getQuad());
+        Quad q = Quad.from(builder.bakeQuad());
         Quad quarter = q.subsect(Submap.fromPixelScale(8, 8, 0, 0));
         Quad half = q.subsect(Submap.fromPixelScale(8, 16, 0, 0));
         Quad center = q.subsect(Submap.fromPixelScale(8, 8, 4, 4));


### PR DESCRIPTION
Draft PR as Neo isn't out for 1.21 yet, and there is some more testing and cleanup I need to do to `TextureMetadataHandler#onModelBake`

I also believe this PR will address the same problem seen in #219, as I got the same stack trace after converting from using `Vec3` to using a `Vector3f` (due to vertex consumers only handling floats), but for all CTM related blocks. It seems that the problem was from CTM still using the old (and now unused, but for some reason not yet removed from vanilla), `Direction#fromDelta`, as opposed to what it seems mojang has moved to of using `Direction#getNearest` for calculating normals.

![2024-06-12_13 04 11](https://github.com/Chisel-Team/ConnectedTexturesMod/assets/1203288/8857e4c4-89cb-4189-b57a-ad916d8dea70)
